### PR TITLE
Allow empty labels that don't get rendered

### DIFF
--- a/src/AdamWathan/Form/Elements/Label.php
+++ b/src/AdamWathan/Form/Elements/Label.php
@@ -13,6 +13,10 @@ class Label extends Element
 
     public function render()
     {
+        if ($this->label === NULL) {
+            return $this->renderElement();
+        }
+
         $result = '<label';
         $result .= $this->renderAttributes();
         $result .= '>';

--- a/tests/LabelTest.php
+++ b/tests/LabelTest.php
@@ -75,4 +75,23 @@ class LabelTest extends PHPUnit_Framework_TestCase
 		$result = $label->after($element)->getControl();
 		$this->assertEquals($element, $result);
 	}
+
+	public function testEmptyLabelDoesNotRender()
+        {
+                $label = new Label(NULL);
+                $expected = '';
+                $result = $label->render();
+                $this->assertEquals($expected, $result);
+        }
+
+        public function testEmptyLabelDoesNotWrap()
+        {
+                $element = Mockery::mock('AdamWathan\Form\Elements\Element');
+                $element->shouldReceive('render')->once()->andReturn('<input>');
+                $label = new Label(NULL);
+                $expected = '<input>';
+
+                $result = $label->before($element)->render();
+                $this->assertEquals($expected, $result);
+        }
 }


### PR DESCRIPTION
I'm using this in the BootForms package to create a `form-group` with `NULL` as the label that doesn't get rendered.
