### PR TITLE
Fix getValueFor to return null, if there is no value to repopulate eleme...

### DIFF
--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -53,7 +53,7 @@ class FormBuilder
     {
         $text = new Text($name);
 
-        if ($value = $this->getValueFor($name)) {
+        if (!is_null($value = $this->getValueFor($name))) {
             $text->value($value);
         }
 
@@ -64,7 +64,7 @@ class FormBuilder
     {
         $date = new Date($name);
 
-        if ($value = $this->getValueFor($name)) {
+        if (!is_null($value = $this->getValueFor($name))) {
             $date->value($value);
         }
 
@@ -75,7 +75,7 @@ class FormBuilder
     {
         $email = new Email($name);
 
-        if ($value = $this->getValueFor($name)) {
+        if (!is_null($value = $this->getValueFor($name))) {
             $email->value($value);
         }
 
@@ -86,7 +86,7 @@ class FormBuilder
     {
         $hidden = new Hidden($name);
 
-        if ($value = $this->getValueFor($name)) {
+        if (!is_null($value = $this->getValueFor($name))) {
             $hidden->value($value);
         }
 
@@ -97,7 +97,7 @@ class FormBuilder
     {
         $textarea = new TextArea($name);
 
-        if ($value = $this->getValueFor($name)) {
+        if (!is_null($value = $this->getValueFor($name))) {
             $textarea->value($value);
         }
 
@@ -224,7 +224,7 @@ class FormBuilder
             return $this->getModelValue($name);
         }
 
-        return '';
+        return null;
     }
 
     protected function hasOldInput($name)

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -390,6 +390,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testBindTextWithIntegerZero()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+		$expected = '<input type="text" name="number" value="0">';
+		$result = (string)$this->form->text('number');
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testBindDate()
 	{
 		$object = $this->getStubObject();
@@ -505,6 +514,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$obj->date_of_birth = new \DateTime('1985-05-06');
 		$obj->gender = 'male';
 		$obj->terms = 'agree';
+		$obj->number = '0';
 		return $obj;
 	}
 }


### PR DESCRIPTION
In Class `FormBuilder` changed the method `getValueFor` to return null if there is no value to repopulate  instead of empty string

So you can compare with `is_null ()`, repopulando the element with the value string `"0"`
