### PR TITLE
add test for integer values in options array

### DIFF
--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -52,6 +52,21 @@ class SelectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testSelectCanBeCreatedWithIntegerKeyValueOptions()
+	{
+		$select = new Select('color', array('0' => 'Red', '1' => 'Blue'));
+		$expected = '<select name="color"><option value="0">Red</option><option value="1">Blue</option></select>';
+		$result = $select->render();
+
+		$this->assertEquals($expected, $result);
+
+		$select = new Select('fruit', array('1' => 'Granny Smith', '0' => 'Blueberry'));
+		$expected = '<select name="fruit"><option value="1">Granny Smith</option><option value="0">Blueberry</option></select>';
+		$result = $select->render();
+
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testCanAddOption()
 	{
 		$select = new Select('color', array('red' => 'Red'));


### PR DESCRIPTION
Hi,

I was using BootForm::select and I was trying to create integer values for the options. I found that if I started my array with '1' the select worked perfectly, but if i started with '0' then it didn't... i think this is because arrays erase the "type" of the key if it equals an integer value

$array = array();
  $array['1'] = 'value';
  var_dump($array);
array(1) { [1]=> string(5) "value" }

my options array looked like this
working ... array('1' => 'Active', '0' => 'Inactive')
broken ... array('0' => 'Inactive', '1' => 'Active')

I am unsure of how to fix the issue, but i thought i would send along a pull with a test to show what i found.

BootForms has been great,
thanks for putting it together!
