### PR TITLE
No error message with input named with brackets

### DIFF
--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -77,17 +77,7 @@ class Select extends FormControl
 
     protected function isSelected($value)
     {
-        if (isset($this->selected)) {
-            if (is_array($this->selected)) {
-                return in_array($value, $this->selected, TRUE);
-            }
-            else {
-                return $this->selected == $value;
-            }
-        }
-        else {
-            return false;
-        }
+        return in_array($value, (array) $this->selected, true);
     }
 
     public function addOption($value, $label)

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -187,6 +187,8 @@ class FormBuilder
             return false;
         }
 
+        $name = $this->transformKey($name);
+
         return $this->errorStore->hasError($name);
     }
 
@@ -199,6 +201,8 @@ class FormBuilder
         if (! $this->hasError($name)) {
             return '';
         }
+
+        $name = $this->transformKey($name);
 
         $message = $this->errorStore->getError($name);
 
@@ -285,5 +289,10 @@ class FormBuilder
         );
 
         return $this->select($name, $options);
+    }
+
+    protected function transformKey($key)
+    {
+        return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
     }
 }


### PR DESCRIPTION
We have this input:

```html
<input type="text" name="customer[name]">
```

and this corresponding validation rule:

```php
$rules = [
    'customer.name' => 'required',
];
```

If empty input is submitted, we should have an error, but no error or message was set.
