### PR TITLE
Start supporting array errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-      "phpunit/phpunit": "3.7.*",
-      "mockery/mockery": "dev-master@dev",
+        "illuminate/support": "4.*",
+        "phpunit/phpunit": "3.7.*",
+        "mockery/mockery": "~0.9",
         "codeclimate/php-test-reporter": "0.1.*@dev"
     },
     "autoload": {

--- a/src/AdamWathan/Form/ErrorStore/IlluminateErrorStore.php
+++ b/src/AdamWathan/Form/ErrorStore/IlluminateErrorStore.php
@@ -17,6 +17,7 @@ class IlluminateErrorStore implements ErrorStoreInterface
             return false;
         }
 
+        $key = $this->transformKey($key);
         return $this->getErrors()->has($key);
     }
 
@@ -26,6 +27,7 @@ class IlluminateErrorStore implements ErrorStoreInterface
             return null;
         }
 
+        $key = $this->transformKey($key);
         return $this->getErrors()->first($key);
     }
 
@@ -37,5 +39,10 @@ class IlluminateErrorStore implements ErrorStoreInterface
     protected function getErrors()
     {
         return $this->hasErrors() ? $this->session->get('errors') : null;
+    }
+
+    protected function transformKey($key)
+    {
+        return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
     }
 }

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -187,8 +187,6 @@ class FormBuilder
             return false;
         }
 
-        $name = $this->transformKey($name);
-
         return $this->errorStore->hasError($name);
     }
 
@@ -201,8 +199,6 @@ class FormBuilder
         if (! $this->hasError($name)) {
             return '';
         }
-
-        $name = $this->transformKey($name);
 
         $message = $this->errorStore->getError($name);
 
@@ -289,10 +285,5 @@ class FormBuilder
         );
 
         return $this->select($name, $options);
-    }
-
-    protected function transformKey($key)
-    {
-        return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
     }
 }

--- a/tests/IlluminateErrorStoreTest.php
+++ b/tests/IlluminateErrorStoreTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use AdamWathan\Form\ErrorStore\IlluminateErrorStore;
+use Illuminate\Support\MessageBag;
+
+class IlluminateErrorStoreTest extends PHPUnit_Framework_TestCase
+{
+    public function test_it_converts_array_keys_to_dot_notation()
+    {
+        $errors = new MessageBag(array(
+            'foo.bar' => 'Some error',
+        ));
+        $session = Mockery::mock('Illuminate\Session\Store');
+        $session->shouldReceive('has')->with('errors')->andReturn(true);
+        $session->shouldReceive('get')->with('errors')->andReturn($errors);
+
+        $errorStore = new IlluminateErrorStore($session);
+        $this->assertTrue($errorStore->hasError('foo[bar]'));
+    }
+}


### PR DESCRIPTION
Incorporates work done in #35.

- Need to add tests for the other cases that `transformKey` is supporting