### PR TITLE
Add support for autofocus attribute

### DIFF
--- a/src/AdamWathan/Form/Elements/Button.php
+++ b/src/AdamWathan/Form/Elements/Button.php
@@ -2,6 +2,7 @@
 
 class Button extends FormControl
 {
+
     protected $attributes = array(
         'type' => 'button',
     );

--- a/src/AdamWathan/Form/Elements/FormControl.php
+++ b/src/AdamWathan/Form/Elements/FormControl.php
@@ -35,4 +35,17 @@ abstract class FormControl extends Element
         $this->removeAttribute('disabled');
         return $this;
     }
+
+    public function autofocus()
+    {
+        $this->setAttribute('autofocus', 'autofocus');
+        return $this;
+    }
+
+    public function unfocus()
+    {
+        $this->removeAttribute('autofocus');
+        return $this;
+    }
+
 }

--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -2,6 +2,7 @@
 
 class Select extends FormControl
 {
+
     private $options;
     private $selected;
 

--- a/src/AdamWathan/Form/Elements/Text.php
+++ b/src/AdamWathan/Form/Elements/Text.php
@@ -2,6 +2,7 @@
 
 class Text extends Input
 {
+
     protected $attributes = array(
         'type' => 'text',
     );

--- a/src/AdamWathan/Form/Elements/TextArea.php
+++ b/src/AdamWathan/Form/Elements/TextArea.php
@@ -2,6 +2,7 @@
 
 class TextArea extends FormControl
 {
+
     protected $attributes = array(
         'name' => '',
         'rows' => 10,

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -117,6 +117,30 @@ class TextTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+    public function testAutofocus()
+    {
+        $text = new Text('');
+
+        $result = $text->autofocus()->render();
+        $message = "autofocus attribute should be set";
+        $this->assertContains('autofocus="autofocus"', $result, $message);
+    }
+
+    public function testUnfocus() {
+        $pattern = 'autofocus="autofocus"';
+        $text = new Text('');
+
+        $result = $text->unfocus()->render();
+        $message = "autofocus attribute should not be set";
+        $this->assertNotContains($pattern, $result, $message);
+
+        $text = new Text('');
+
+        $result = $text->autofocus()->unfocus()->render();
+        $message = "autofocus attribute should be removed";
+        $this->assertNotContains($pattern, $result, $message);
+    }
+
 	public function testOptional()
 	{
 		$text = new Text('email');


### PR DESCRIPTION
HTML5 introduces autofocus attribute for text,
textarea, select, and button elements:
https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Forms_in_HTML#The_autofocus_attribute

This implements a Trait with methods for (un)setting this attribute
and applies it to Text, TextArea, Select, and Button classes.