### PR TITLE
Change function getValueFor for access public

### DIFF
--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -214,7 +214,7 @@ class FormBuilder
         $this->model = is_array($model) ? (object) $model : $model;
     }
 
-    protected function getValueFor($name)
+    public function getValueFor($name)
     {
         if ($this->hasOldInput()) {
             return $this->getOldInput($name);


### PR DESCRIPTION
This change is interesting because if you need the current value of the element we can use
```php
BootForm::getValueFor('name')
```