### PR TITLE
Added hasOldInputFor() method to FormBuilder

### DIFF
--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -227,7 +227,7 @@ class FormBuilder
 
     public function getValueFor($name)
     {
-        if ($this->hasOldInput()) {
+        if ($this->hasOldInputFor($name)) {
             return $this->getOldInput($name);
         }
 
@@ -236,6 +236,19 @@ class FormBuilder
         }
 
         return null;
+    }
+
+    protected function hasOldInputFor($name)
+    {
+        if(! $this->hasOldInput()) {
+            return false;
+        }
+
+        if(! $this->getOldInput($name)) {
+            return false;
+        }
+
+        return true;
     }
 
     protected function hasOldInput()


### PR DESCRIPTION
I am using this on a "Member Account" page in an Admin Dashboard that has multiple forms to update specific aspects of a member's account. All forms are being bound to the member object passed to the view.

There are forms for things like:
- Member's contact info
- Member's account details (username, user level, account status)
- Password reset

I was having a problem where if a field failed to validate on the Account Details form, for instance, the Contact Info. form would not be populated on redirect back.

This will solve that issue with multiple bound forms as it will check old input for a specific key, as opposed to just ANY old input, and then fallback to the bound model value.
