### PR TITLE
New method for setting multiple on selects.

### DIFF
--- a/src/AdamWathan/Form/Elements/Element.php
+++ b/src/AdamWathan/Form/Elements/Element.php
@@ -91,6 +91,7 @@ abstract class Element
 
     public function __call($method, $params)
     {
+        $params = count($params) ? $params : array($method);
         $params = array_merge(array($method), $params);
         call_user_func_array(array($this, 'attribute'), $params);
         return $this;

--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -5,13 +5,10 @@ class Select extends FormControl
 
     private $options;
     private $selected;
-    private $name;
 
     public function __construct($name, $options = array())
     {
-        $this->name = $name;
         $this->setName($name);
-
         $this->setOptions($options);
     }
 
@@ -102,7 +99,7 @@ class Select extends FormControl
 
     public function multiple()
     {
-        $name = $this->name;
+        $name = $this->attributes['name'];
         if (substr($name, -2) != '[]') {
             $name .= '[]';
         }

--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -5,10 +5,13 @@ class Select extends FormControl
 
     private $options;
     private $selected;
+    private $name;
 
     public function __construct($name, $options = array())
     {
+        $this->name = $name;
         $this->setName($name);
+
         $this->setOptions($options);
     }
 
@@ -94,6 +97,13 @@ class Select extends FormControl
         }
 
         $this->select($value);
+        return $this;
+    }
+
+    public function multiple()
+    {
+        $this->setName($this->name . '[]');
+        $this->setAttribute('multiple', 'multiple');
         return $this;
     }
 }

--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -102,7 +102,12 @@ class Select extends FormControl
 
     public function multiple()
     {
-        $this->setName($this->name . '[]');
+        $name = $this->name;
+        if (substr($name, -2) != '[]') {
+            $name .= '[]';
+        }
+
+        $this->setName($name);
         $this->setAttribute('multiple', 'multiple');
         return $this;
     }

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -241,4 +241,13 @@ class SelectTest extends PHPUnit_Framework_TestCase
 		$result = $select->render();
 		$this->assertEquals($expected, $result);
 	}
+
+	public function testSelectCanBeMultiple()
+	{
+		$select = new Select('people');
+		$expected = '<select name="people[]" multiple="multiple"></select>';
+		$result = $select->multiple()->render();
+
+		$this->assertEquals($expected, $result);
+	}
 }

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -249,5 +249,11 @@ class SelectTest extends PHPUnit_Framework_TestCase
 		$result = $select->multiple()->render();
 
 		$this->assertEquals($expected, $result);
+
+		$select = new Select('people[]');
+		$expected = '<select name="people[]" multiple="multiple"></select>';
+		$result = $select->multiple()->render();
+
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -260,4 +260,14 @@ class TextTest extends PHPUnit_Framework_TestCase
 		$result = $text->render();
 		$this->assertEquals($expected, $result);
 	}
+
+	public function testCanAddAttributesThroughMagicMethodsWithOptionalParameter()
+	{
+		$text = new Text('cow');
+		$text = $text->moo();
+
+		$expected = '<input type="text" name="cow" moo="moo">';
+		$result = $text->render();
+		$this->assertEquals($expected, $result);
+	}
 }


### PR DESCRIPTION
Chaining multiple() method:
`$builder->select('people')->multiple();`

Generates:
`<select name="people[]" multiple="multiple"></select>`;

Great for tags, etc.
![Example](http://puu.sh/hOtnc/1852cccf8b.png)