### PR TITLE
Element improvements.

### DIFF
--- a/src/AdamWathan/Form/Elements/Element.php
+++ b/src/AdamWathan/Form/Elements/Element.php
@@ -18,6 +18,11 @@ abstract class Element
         unset($this->attributes[$attribute]);
     }
 
+    public function type()
+    {
+        return $this->attributes['type'];
+    }
+
     public function data($attribute, $value)
     {
         $this->setAttribute('data-'.$attribute, $value);

--- a/src/AdamWathan/Form/Elements/Element.php
+++ b/src/AdamWathan/Form/Elements/Element.php
@@ -55,7 +55,13 @@ abstract class Element
         if (! isset($this->attributes['class'])) {
             return $this;
         }
+
         $class = trim(str_replace($class, '', $this->attributes['class']));
+        if ($class == '') {
+            $this->removeAttribute('class');
+            return $this;
+        }
+
         $this->setAttribute('class', $class);
         return $this;
     }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -533,6 +533,13 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testGetTypeAttribute()
+	{
+		$expected = 'radio';
+		$result = $this->form->radio('fm-transmission')->type();
+		$this->assertEquals($expected, $result);
+	}
+
 	private function getStubObject()
 	{
 		$obj = new stdClass;

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -526,6 +526,13 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRemoveClass()
+	{
+		$expected = '<input type="text" name="food">';
+		$result = (string)$this->form->text('food')->addClass('sandwich pizza')->removeClass('sandwich')->removeClass('pizza');
+		$this->assertEquals($expected, $result);
+	}
+
 	private function getStubObject()
 	{
 		$obj = new stdClass;


### PR DESCRIPTION
```php
$element->addClass('sandwich pizza')
// class="sandwich pizza"

$element->removeClass('pizza')
// class="sandwich"

$element->removeClass('sandwich')
// class=""
```
This empty class is not only useless, but problematic.  Now if we addClass()...
```php
$element->addClass('fries')
// class=" fries"
```
We get unwanted whitespace in our class output, which makes some of my tests fail in my BootForms PR.

This fix will remove class attribute entirely when there's nothing left:
```php
$element->addClass('sandwich pizza')->removeClass('sandwich')->removeClass('pizza')
// No class attribute in output; As if class attribute was never added.
```