### PR TITLE
Avoid to pass "_token" value through query string

### DIFF
--- a/src/AdamWathan/Form/Elements/FormOpen.php
+++ b/src/AdamWathan/Form/Elements/FormOpen.php
@@ -16,7 +16,7 @@ class FormOpen extends Element
         $result .= $this->renderAttributes();
         $result .= '>';
 
-        if ($this->hasToken()) {
+        if ($this->hasToken() && ($this->attributes['method'] !== 'GET')) {
             $result .= $this->token->render();
         }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -381,6 +381,14 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testTokenIsNotRenderedAutomaticallyOnOpenFormWithGetMethodIfSet()
+	{
+		$this->form->setToken('12345');
+		$expected = '<form method="GET" action="">';
+		$result = (string)$this->form->open()->get();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testSelectMonth()
 	{
 		$expected = '<select name="month"><option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option value="10">October</option><option value="11">November</option><option value="12">December</option></select>';


### PR DESCRIPTION
This patch prevent urls like http://blog.local/admin/posts/?_token=FGeYWnYVdmy7HEBret1OprY3IAYCzdNi3ESlINCG&status=active&name=test