### PR TITLE
Old input binding fix for checkbox & radio when chaining value()

### DIFF
--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -16,6 +16,11 @@ class Checkbox extends Input
         $this->setValue($value);
     }
 
+    public function setOldValue($oldValue)
+    {
+        $this->oldValue = $oldValue;
+    }
+
     public function defaultToChecked()
     {
         if (! isset($this->checked)) {
@@ -62,17 +67,12 @@ class Checkbox extends Input
         }
     }
 
-    public function setOldValue($oldValue)
-    {
-        $this->oldValue = $oldValue;
-    }
-
     protected function checkBinding()
     {
         $currentValue = $this->getAttribute('value');
         $oldValue = $this->oldValue;
 
-        if ($currentValue == $oldValue) {
+        if ($currentValue === $oldValue) {
             $this->check();
         }
     }

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -8,6 +8,8 @@ class Checkbox extends Input
 
     private $checked;
 
+    private $oldValue;
+
     public function __construct($name, $value = 1)
     {
         parent::__construct($name);
@@ -58,5 +60,27 @@ class Checkbox extends Input
         if ($checked) {
             $this->setAttribute('checked', 'checked');
         }
+    }
+
+    public function setOldValue($oldValue)
+    {
+        $this->oldValue = $oldValue;
+    }
+
+    protected function checkBinding()
+    {
+        $currentValue = $this->getAttribute('value');
+        $oldValue = $this->oldValue;
+
+        if ($currentValue == $oldValue) {
+            $this->check();
+        }
+    }
+
+    public function render()
+    {
+        $this->checkBinding();
+
+        return parent::render();
     }
 }

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -72,7 +72,7 @@ class Checkbox extends Input
         $currentValue = $this->getAttribute('value');
         $oldValue = $this->oldValue;
 
-        if ($currentValue == $oldValue) {
+        if ($currentValue === $oldValue) {
             $this->check();
         }
     }

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -72,7 +72,7 @@ class Checkbox extends Input
         $currentValue = $this->getAttribute('value');
         $oldValue = $this->oldValue;
 
-        if ($currentValue === $oldValue) {
+        if ($currentValue == $oldValue) {
             $this->check();
         }
     }

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -125,10 +125,7 @@ class FormBuilder
         $checkbox = new Checkbox($name, $value);
 
         $oldValue = $this->getValueFor($name);
-
-        if ($value == $oldValue) {
-            $checkbox->check();
-        }
+        $checkbox->setOldValue($oldValue);
 
         return $checkbox;
     }
@@ -140,10 +137,7 @@ class FormBuilder
         $radio = new RadioButton($name, $value);
 
         $oldValue = $this->getValueFor($name);
-
-        if ($value == $oldValue) {
-            $radio->check();
-        }
+        $radio->setOldValue($oldValue);
 
         return $radio;
     }

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -132,8 +132,6 @@ class FormBuilder
 
     public function radio($name, $value = null)
     {
-        $value = is_null($value) ? $name : $value;
-
         $radio = new RadioButton($name, $value);
 
         $oldValue = $this->getValueFor($name);

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -189,37 +189,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testRenderCheckboxWithOldInputAgainstBinaryValue()
+	public function testRenderCheckboxAgainstBinaryZero()
 	{
-		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
-		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
-		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn(1);
-
-		$this->form->setOldInputProvider($oldInput);
-
 		$expected = '<input type="checkbox" name="boolean" value="0">';
 		$result = (string)$this->form->checkbox('boolean', 0);
 		$this->assertEquals($expected, $result);
-
-		$expected = '<input type="checkbox" name="boolean" value="1" checked="checked">';
-		$result = (string)$this->form->checkbox('boolean', 1);
-		$this->assertEquals($expected, $result);
 	}
 
-	public function testRenderRadioWithOldInputAgainstBinaryValue()
+	public function testRenderRadioAgainstBinaryZero()
 	{
-		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
-		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
-		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn(1);
-
-		$this->form->setOldInputProvider($oldInput);
-
 		$expected = '<input type="radio" name="boolean" value="0">';
 		$result = (string)$this->form->radio('boolean', 0);
-		$this->assertEquals($expected, $result);
-
-		$expected = '<input type="radio" name="boolean" value="1" checked="checked">';
-		$result = (string)$this->form->radio('boolean')->value(1);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -64,6 +64,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected = '<input type="checkbox" name="terms" value="agree">';
 		$result = (string)$this->form->checkbox('terms', 'agree');
 		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="checkbox" name="terms" value="agree">';
+		$result = (string)$this->form->checkbox('terms')->value('agree');
+		$this->assertEquals($expected, $result);
 	}
 
 	public function testRadio()
@@ -74,6 +78,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$expected = '<input type="radio" name="terms" value="agree">';
 		$result = (string)$this->form->radio('terms', 'agree');
+		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="radio" name="terms" value="agree">';
+		$result = (string)$this->form->radio('terms')->value('agree');
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -159,7 +159,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$result = (string)$this->form->checkbox('terms', 'agree');
 		$this->assertEquals($expected, $result);
 
-        $expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
+		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
 		$result = (string)$this->form->checkbox('terms')->value('agree');
 		$this->assertEquals($expected, $result);
 	}
@@ -176,9 +176,9 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$result = (string)$this->form->radio('color', 'green');
 		$this->assertEquals($expected, $result);
 
-        $expected = '<input type="radio" name="color" value="green" checked="checked">';
-        $result = (string)$this->form->radio('color')->value('green');
-        $this->assertEquals($expected, $result);
+		$expected = '<input type="radio" name="color" value="green" checked="checked">';
+		$result = (string)$this->form->radio('color')->value('green');
+		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderSelectWithOldInput()

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -158,6 +158,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
 		$result = (string)$this->form->checkbox('terms', 'agree');
 		$this->assertEquals($expected, $result);
+
+        $expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
+		$result = (string)$this->form->checkbox('terms')->value('agree');
+		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderRadioWithOldInput()
@@ -171,6 +175,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected = '<input type="radio" name="color" value="green" checked="checked">';
 		$result = (string)$this->form->radio('color', 'green');
 		$this->assertEquals($expected, $result);
+
+        $expected = '<input type="radio" name="color" value="green" checked="checked">';
+        $result = (string)$this->form->radio('color')->value('green');
+        $this->assertEquals($expected, $result);
 	}
 
 	public function testRenderSelectWithOldInput()
@@ -183,6 +191,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
 		$result = (string)$this->form->select('color', array('red' => 'Red', 'blue' => 'Blue'));
+		$this->assertEquals($expected, $result);
+
+		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
+		$result = (string)$this->form->select('color')->options(array('red' => 'Red', 'blue' => 'Blue'));
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -189,6 +189,40 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderCheckboxWithOldInputAgainstBinaryValue()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn('green');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="checkbox" name="boolean" value="0">';
+		$result = (string)$this->form->checkbox('boolean', 0);
+		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="checkbox" name="boolean" value="0">';
+		$result = (string)$this->form->checkbox('boolean')->value(0);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderRadioWithOldInputAgainstBinaryValue()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn('green');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="radio" name="boolean" value="0">';
+		$result = (string)$this->form->radio('boolean', 0);
+		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="radio" name="boolean" value="0">';
+		$result = (string)$this->form->radio('boolean')->value(0);
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderSelectWithOldInput()
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -193,7 +193,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
 		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
-		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn('green');
+		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn(1);
 
 		$this->form->setOldInputProvider($oldInput);
 
@@ -201,8 +201,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$result = (string)$this->form->checkbox('boolean', 0);
 		$this->assertEquals($expected, $result);
 
-		$expected = '<input type="checkbox" name="boolean" value="0">';
-		$result = (string)$this->form->checkbox('boolean')->value(0);
+		$expected = '<input type="checkbox" name="boolean" value="1" checked="checked">';
+		$result = (string)$this->form->checkbox('boolean', 1);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -210,7 +210,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
 		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
-		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn('green');
+		$oldInput->shouldReceive('getOldInput')->with('boolean')->andReturn(1);
 
 		$this->form->setOldInputProvider($oldInput);
 
@@ -218,8 +218,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$result = (string)$this->form->radio('boolean', 0);
 		$this->assertEquals($expected, $result);
 
-		$expected = '<input type="radio" name="boolean" value="0">';
-		$result = (string)$this->form->radio('boolean')->value(0);
+		$expected = '<input type="radio" name="boolean" value="1" checked="checked">';
+		$result = (string)$this->form->radio('boolean')->value(1);
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
Old input binding doesn't work on checkbox & radio when chaining `->value()`.
```php
$form->radio('my_field')->value($value)
```

But it does work when passing value into element constructor:
```php
$form->radio('my_field', $value)
```
I narrowed down to [this code](https://github.com/adamwathan/form/blob/master/src/AdamWathan/Form/FormBuilder.php#L123-L149).  Since old input binding on checkbox and radio elements require checking against the element's value, we can't perform this logic in the constructor because it ignores the fact that the user could have set the value later with `value()`.  My proposed fix saves old input onto the element as private property, so that the binding logic can be performed later.

I feel like it's kind of dirty saving old input on the element as a property, but I couldn't find a way to access the parent form object from within the element object.  Open to your thoughts.