### PR TITLE
Fix checkbox/radio binding precedence

### DIFF
--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -21,6 +21,11 @@ class Checkbox extends Input
         $this->oldValue = $oldValue;
     }
 
+    public function unsetOldValue()
+    {
+        $this->oldValue = null;
+    }
+
     public function defaultToChecked()
     {
         if (! isset($this->checked)) {
@@ -53,6 +58,7 @@ class Checkbox extends Input
 
     public function uncheck()
     {
+        $this->unsetOldValue();
         $this->setChecked(false);
         return $this;
     }

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -52,6 +52,7 @@ class Checkbox extends Input
 
     public function check()
     {
+        $this->unsetOldValue();
         $this->setChecked(true);
         return $this;
     }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -189,7 +189,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testRenderCheckboxWithOldInputAndForceUncheck()
+	public function testExplicitUncheckOnCheckboxTakesPrecedenceOverOldInput()
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
 		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
@@ -202,7 +202,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testRenderRadioWithOldInputAndForceUncheck()
+	public function testExplicitUncheckOnRadioTakesPrecedenceOverOldInput()
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
 		$oldInput->shouldReceive('hasOldInput')->andReturn(true);

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -547,6 +547,24 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testExplicitUncheckOnCheckboxTakesPrecedenceOverBinding()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+		$expected = '<input type="radio" name="terms" value="agree">';
+		$result = (string)$this->form->radio('terms', 'agree')->uncheck();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testExplicitUncheckOnRadioTakesPrecedenceOverBinding()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+		$expected = '<input type="radio" name="color" value="green">';
+		$result = (string)$this->form->radio('color', 'green')->uncheck();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testBindUnsetProperty()
 	{
 		$object = $this->getStubObject();
@@ -617,6 +635,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$obj->date_of_birth = new \DateTime('1985-05-06');
 		$obj->gender = 'male';
 		$obj->terms = 'agree';
+		$obj->color = 'green';
 		$obj->number = '0';
 		return $obj;
 	}

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -565,6 +565,24 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testExplicitCheckOnCheckboxTakesPrecedenceOverBinding()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+		$expected = '<input type="radio" name="terms" value="agree" checked="checked">';
+		$result = (string)$this->form->radio('terms', 'agree')->check();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testExplicitCheckOnRadioTakesPrecedenceOverBinding()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+		$expected = '<input type="radio" name="color" value="green" checked="checked">';
+		$result = (string)$this->form->radio('color', 'green')->check();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testBindUnsetProperty()
 	{
 		$object = $this->getStubObject();

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -189,6 +189,32 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderCheckboxWithOldInputAndForceUncheck()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('terms')->andReturn('agree');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="checkbox" name="terms" value="agree">';
+		$result = (string)$this->form->checkbox('terms', 'agree')->uncheck();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderRadioWithOldInputAndForceUncheck()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('color')->andReturn('green');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="radio" name="color" value="green">';
+		$result = (string)$this->form->radio('color', 'green')->uncheck();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderCheckboxAgainstBinaryZero()
 	{
 		$expected = '<input type="checkbox" name="boolean" value="0">';

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -210,6 +210,32 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$this->form->setOldInputProvider($oldInput);
 
+		$expected = '<input type="radio" name="color" value="green" checked="checked">';
+		$result = (string)$this->form->radio('color', 'green')->check();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testExplicitCheckOnCheckboxTakesPrecedenceOverOldInput()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('terms')->andReturn('agree');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
+		$result = (string)$this->form->checkbox('terms', 'agree')->check();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testExplicitCheckOnRadioTakesPrecedenceOverOldInput()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('color')->andReturn('green');
+
+		$this->form->setOldInputProvider($oldInput);
+
 		$expected = '<input type="radio" name="color" value="green">';
 		$result = (string)$this->form->radio('color', 'green')->uncheck();
 		$this->assertEquals($expected, $result);

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -210,8 +210,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$this->form->setOldInputProvider($oldInput);
 
-		$expected = '<input type="radio" name="color" value="green" checked="checked">';
-		$result = (string)$this->form->radio('color', 'green')->check();
+		$expected = '<input type="radio" name="color" value="green">';
+		$result = (string)$this->form->radio('color', 'green')->uncheck();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -236,8 +236,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$this->form->setOldInputProvider($oldInput);
 
-		$expected = '<input type="radio" name="color" value="green">';
-		$result = (string)$this->form->radio('color', 'green')->uncheck();
+		$expected = '<input type="radio" name="color" value="green" checked="checked">';
+		$result = (string)$this->form->radio('color', 'green')->check();
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
As per our conversation...

If `uncheck()` is called on a checkbox or radio control, it should take precedence over old input / model binding.

Example:

```php
$form->checkbox('terms')->value('agree')->uncheck();
```

An 'agree to terms' checkbox should always be unchecked on page load, forcing the user to manually agree.  Old input / model binding should never take precedence if `uncheck()` is used.