### PR TITLE
Fix checkbox array binding

### DIFF
--- a/src/AdamWathan/Form/Elements/Button.php
+++ b/src/AdamWathan/Form/Elements/Button.php
@@ -2,10 +2,9 @@
 
 class Button extends FormControl
 {
-
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'button',
-    );
+    ];
 
     protected $value;
 

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -18,12 +18,6 @@ class Checkbox extends Input
 
     public function setOldValue($oldValue)
     {
-        $value = $this->getAttribute('value');
-
-        if (is_array($oldValue) && in_array($value, $oldValue)) {
-            $oldValue = $value;
-        }
-
         $this->oldValue = $oldValue;
     }
 
@@ -85,8 +79,12 @@ class Checkbox extends Input
         $currentValue = $this->getAttribute('value');
         $oldValue = $this->oldValue;
 
+        if (is_array($oldValue) && in_array($currentValue, $oldValue)) {
+             return $this->check();
+        }
+
         if ($currentValue === $oldValue) {
-            $this->check();
+            return $this->check();
         }
     }
 

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -76,14 +76,13 @@ class Checkbox extends Input
 
     protected function checkBinding()
     {
-        $currentValue = $this->getAttribute('value');
+        $currentValue = (string) $this->getAttribute('value');
+
         $oldValue = $this->oldValue;
+        $oldValue = is_array($oldValue) ? $oldValue : array($oldValue);
+        $oldValue = array_map('strval', $oldValue);
 
-        if (is_array($oldValue) && in_array($currentValue, $oldValue)) {
-             return $this->check();
-        }
-
-        if ($currentValue === $oldValue) {
+        if (in_array($currentValue, $oldValue)) {
             return $this->check();
         }
     }

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -2,9 +2,9 @@
 
 class Checkbox extends Input
 {
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'checkbox',
-    );
+    ];
 
     private $checked;
 
@@ -79,7 +79,7 @@ class Checkbox extends Input
         $currentValue = (string) $this->getAttribute('value');
 
         $oldValue = $this->oldValue;
-        $oldValue = is_array($oldValue) ? $oldValue : array($oldValue);
+        $oldValue = is_array($oldValue) ? $oldValue : [$oldValue];
         $oldValue = array_map('strval', $oldValue);
 
         if (in_array($currentValue, $oldValue)) {

--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -18,6 +18,12 @@ class Checkbox extends Input
 
     public function setOldValue($oldValue)
     {
+        $value = $this->getAttribute('value');
+
+        if (is_array($oldValue) && in_array($value, $oldValue)) {
+            $oldValue = $value;
+        }
+
         $this->oldValue = $oldValue;
     }
 

--- a/src/AdamWathan/Form/Elements/Date.php
+++ b/src/AdamWathan/Form/Elements/Date.php
@@ -2,9 +2,9 @@
 
 class Date extends Text
 {
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'date',
-    );
+    ];
 
     public function value($value)
     {

--- a/src/AdamWathan/Form/Elements/Element.php
+++ b/src/AdamWathan/Form/Elements/Element.php
@@ -2,7 +2,7 @@
 
 abstract class Element
 {
-    protected $attributes = array();
+    protected $attributes = [];
 
     protected function setAttribute($attribute, $value = null)
     {
@@ -109,9 +109,9 @@ abstract class Element
 
     public function __call($method, $params)
     {
-        $params = count($params) ? $params : array($method);
-        $params = array_merge(array($method), $params);
-        call_user_func_array(array($this, 'attribute'), $params);
+        $params = count($params) ? $params : [$method];
+        $params = array_merge([$method], $params);
+        call_user_func_array([$this, 'attribute'], $params);
         return $this;
     }
 }

--- a/src/AdamWathan/Form/Elements/Email.php
+++ b/src/AdamWathan/Form/Elements/Email.php
@@ -2,7 +2,7 @@
 
 class Email extends Text
 {
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'email',
-    );
+    ];
 }

--- a/src/AdamWathan/Form/Elements/File.php
+++ b/src/AdamWathan/Form/Elements/File.php
@@ -2,7 +2,7 @@
 
 class File extends Input
 {
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'file',
-    );
+    ];
 }

--- a/src/AdamWathan/Form/Elements/FormOpen.php
+++ b/src/AdamWathan/Form/Elements/FormOpen.php
@@ -2,10 +2,10 @@
 
 class FormOpen extends Element
 {
-    protected $attributes = array(
+    protected $attributes = [
         'method' => 'POST',
         'action' => '',
-    );
+    ];
 
     protected $token;
     protected $hiddenMethod;

--- a/src/AdamWathan/Form/Elements/Hidden.php
+++ b/src/AdamWathan/Form/Elements/Hidden.php
@@ -2,7 +2,7 @@
 
 class Hidden extends Input
 {
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'hidden',
-    );
+    ];
 }

--- a/src/AdamWathan/Form/Elements/Password.php
+++ b/src/AdamWathan/Form/Elements/Password.php
@@ -2,7 +2,7 @@
 
 class Password extends Text
 {
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'password',
-    );
+    ];
 }

--- a/src/AdamWathan/Form/Elements/RadioButton.php
+++ b/src/AdamWathan/Form/Elements/RadioButton.php
@@ -2,9 +2,9 @@
 
 class RadioButton extends Checkbox
 {
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'radio',
-    );
+    ];
 
     public function __construct($name, $value = null)
     {

--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -2,11 +2,10 @@
 
 class Select extends FormControl
 {
-
     private $options;
     private $selected;
 
-    public function __construct($name, $options = array())
+    public function __construct($name, $options = [])
     {
         $this->setName($name);
         $this->setOptions($options);

--- a/src/AdamWathan/Form/Elements/Text.php
+++ b/src/AdamWathan/Form/Elements/Text.php
@@ -2,10 +2,9 @@
 
 class Text extends Input
 {
-
-    protected $attributes = array(
+    protected $attributes = [
         'type' => 'text',
-    );
+    ];
 
     public function placeholder($placeholder)
     {

--- a/src/AdamWathan/Form/Elements/TextArea.php
+++ b/src/AdamWathan/Form/Elements/TextArea.php
@@ -2,12 +2,11 @@
 
 class TextArea extends FormControl
 {
-
-    protected $attributes = array(
+    protected $attributes = [
         'name' => '',
         'rows' => 10,
         'cols' => 50,
-    );
+    ];
 
     protected $value;
 

--- a/src/AdamWathan/Form/ErrorStore/IlluminateErrorStore.php
+++ b/src/AdamWathan/Form/ErrorStore/IlluminateErrorStore.php
@@ -43,6 +43,6 @@ class IlluminateErrorStore implements ErrorStoreInterface
 
     protected function transformKey($key)
     {
-        return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
+        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $key);
     }
 }

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -153,7 +153,7 @@ class FormBuilder
         return $submit;
     }
 
-    public function select($name, $options = array())
+    public function select($name, $options = [])
     {
         $select = new Select($name, $options);
 
@@ -274,7 +274,7 @@ class FormBuilder
 
     public function selectMonth($name)
     {
-        $options = array(
+        $options = [
             "1" => "January",
             "2" => "February",
             "3" => "March",
@@ -287,13 +287,13 @@ class FormBuilder
             "10" => "October",
             "11" => "November",
             "12" => "December",
-        );
+        ];
 
         return $this->select($name, $options);
     }
 
     protected function transformKey($key)
     {
-        return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
+        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $key);
     }
 }

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -219,6 +219,8 @@ class FormBuilder
 
     public function getValueFor($name)
     {
+        $name = $this->transformKey($name);
+
         if ($this->hasOldInput()) {
             return $this->getOldInput($name);
         }
@@ -288,5 +290,10 @@ class FormBuilder
         );
 
         return $this->select($name, $options);
+    }
+
+    protected function transformKey($key)
+    {
+        return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
     }
 }

--- a/src/AdamWathan/Form/FormServiceProvider.php
+++ b/src/AdamWathan/Form/FormServiceProvider.php
@@ -58,6 +58,6 @@ class FormServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array('adamwathan.form');
+        return ['adamwathan.form'];
     }
 }

--- a/src/AdamWathan/Form/OldInput/IlluminateOldInputProvider.php
+++ b/src/AdamWathan/Form/OldInput/IlluminateOldInputProvider.php
@@ -23,6 +23,6 @@ class IlluminateOldInputProvider implements OldInputInterface
 
     protected function transformKey($key)
     {
-        return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
+        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $key);
     }
 }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -269,6 +269,19 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderCheckboxAgainstBinaryOldInput()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('agree_to_terms')->andReturn('1');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="checkbox" name="agree_to_terms" value="1" checked="checked">';
+		$result = (string)$this->form->checkbox('agree_to_terms', 1);
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderRadioAgainstBinaryZero()
 	{
 		$expected = '<input type="radio" name="boolean" value="0">';

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -22,73 +22,73 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testFormOpen()
 	{
 		$expected = '<form method="POST" action="">';
-		$result = (string)$this->form->open();
+		$result = (string) $this->form->open();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testCanCloseForm()
 	{
 		$expected = '</form>';
-		$result = (string)$this->form->close();
+		$result = (string) $this->form->close();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testTextBox()
 	{
 		$expected = '<input type="text" name="email">';
-		$result = (string)$this->form->text('email');
+		$result = (string) $this->form->text('email');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="text" name="first_name">';
-		$result = (string)$this->form->text('first_name');
+		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testPassword()
 	{
 		$expected = '<input type="password" name="password">';
-		$result = (string)$this->form->password('password');
+		$result = (string) $this->form->password('password');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="password" name="password_confirmed">';
-		$result = (string)$this->form->password('password_confirmed');
+		$result = (string) $this->form->password('password_confirmed');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testCheckbox()
 	{
 		$expected = '<input type="checkbox" name="terms" value="1">';
-		$result = (string)$this->form->checkbox('terms');
+		$result = (string) $this->form->checkbox('terms');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="checkbox" name="terms" value="agree">';
-		$result = (string)$this->form->checkbox('terms', 'agree');
+		$result = (string) $this->form->checkbox('terms', 'agree');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="checkbox" name="terms" value="agree">';
-		$result = (string)$this->form->checkbox('terms')->value('agree');
+		$result = (string) $this->form->checkbox('terms')->value('agree');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRadio()
 	{
 		$expected = '<input type="radio" name="terms" value="terms">';
-		$result = (string)$this->form->radio('terms');
+		$result = (string) $this->form->radio('terms');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="radio" name="terms" value="agree">';
-		$result = (string)$this->form->radio('terms', 'agree');
+		$result = (string) $this->form->radio('terms', 'agree');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="radio" name="terms" value="agree">';
-		$result = (string)$this->form->radio('terms')->value('agree');
+		$result = (string) $this->form->radio('terms')->value('agree');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testSubmit()
 	{
 		$expected = '<button type="submit">Sign In</button>';
-		$result = (string)$this->form->submit('Sign In');
+		$result = (string) $this->form->submit('Sign In');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -97,7 +97,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testButton($value, $name, $expected)
 	{
-		$result = (string)$this->form->button($value, $name);
+		$result = (string) $this->form->button($value, $name);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -112,33 +112,33 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testSelect()
 	{
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue">Blue</option></select>';
-		$result = (string)$this->form->select('color', ['red' => 'Red', 'blue' => 'Blue']);
+		$result = (string) $this->form->select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$this->assertEquals($expected, $result);
 
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry">Blueberry</option></select>';
-		$result = (string)$this->form->select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
+		$result = (string) $this->form->select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testTextArea()
 	{
 		$expected = '<textarea name="bio" rows="10" cols="50"></textarea>';
-		$result = (string)$this->form->textarea('bio');
+		$result = (string) $this->form->textarea('bio');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<textarea name="description" rows="10" cols="50"></textarea>';
-		$result = (string)$this->form->textarea('description');
+		$result = (string) $this->form->textarea('description');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testLabel()
 	{
 		$expected = '<label>Email</label>';
-		$result = (string)$this->form->label('Email');
+		$result = (string) $this->form->label('Email');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<label>First Name</label>';
-		$result = (string)$this->form->label('First Name');
+		$result = (string) $this->form->label('First Name');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -151,7 +151,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="text" name="title" value="Hello &quot;quotes&quot;">';
-		$result = (string)$this->form->text('title');
+		$result = (string) $this->form->text('title');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -164,11 +164,11 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
-		$result = (string)$this->form->checkbox('terms', 'agree');
+		$result = (string) $this->form->checkbox('terms', 'agree');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
-		$result = (string)$this->form->checkbox('terms')->value('agree');
+		$result = (string) $this->form->checkbox('terms')->value('agree');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -181,15 +181,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked="checked">';
-		$result = (string)$this->form->checkbox('favourite_foods[]', 'fish');
+		$result = (string) $this->form->checkbox('favourite_foods[]', 'fish');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="checkbox" name="favourite_foods[]" value="tofu">';
-		$result = (string)$this->form->checkbox('favourite_foods[]', 'tofu');
+		$result = (string) $this->form->checkbox('favourite_foods[]', 'tofu');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked="checked">';
-		$result = (string)$this->form->checkbox('favourite_foods[]', 'chips');
+		$result = (string) $this->form->checkbox('favourite_foods[]', 'chips');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -202,11 +202,11 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="radio" name="color" value="green" checked="checked">';
-		$result = (string)$this->form->radio('color', 'green');
+		$result = (string) $this->form->radio('color', 'green');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="radio" name="color" value="green" checked="checked">';
-		$result = (string)$this->form->radio('color')->value('green');
+		$result = (string) $this->form->radio('color')->value('green');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -219,7 +219,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="checkbox" name="terms" value="agree">';
-		$result = (string)$this->form->checkbox('terms', 'agree')->uncheck();
+		$result = (string) $this->form->checkbox('terms', 'agree')->uncheck();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -232,7 +232,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="radio" name="color" value="green">';
-		$result = (string)$this->form->radio('color', 'green')->uncheck();
+		$result = (string) $this->form->radio('color', 'green')->uncheck();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -245,7 +245,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
-		$result = (string)$this->form->checkbox('terms', 'agree')->check();
+		$result = (string) $this->form->checkbox('terms', 'agree')->check();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -258,14 +258,14 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="radio" name="color" value="green" checked="checked">';
-		$result = (string)$this->form->radio('color', 'green')->check();
+		$result = (string) $this->form->radio('color', 'green')->check();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderCheckboxAgainstBinaryZero()
 	{
 		$expected = '<input type="checkbox" name="boolean" value="0">';
-		$result = (string)$this->form->checkbox('boolean', 0);
+		$result = (string) $this->form->checkbox('boolean', 0);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -278,14 +278,14 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="checkbox" name="agree_to_terms" value="1" checked="checked">';
-		$result = (string)$this->form->checkbox('agree_to_terms', 1);
+		$result = (string) $this->form->checkbox('agree_to_terms', 1);
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderRadioAgainstBinaryZero()
 	{
 		$expected = '<input type="radio" name="boolean" value="0">';
-		$result = (string)$this->form->radio('boolean', 0);
+		$result = (string) $this->form->radio('boolean', 0);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -298,11 +298,11 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
-		$result = (string)$this->form->select('color', ['red' => 'Red', 'blue' => 'Blue']);
+		$result = (string) $this->form->select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$this->assertEquals($expected, $result);
 
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
-		$result = (string)$this->form->select('color')->options(['red' => 'Red', 'blue' => 'Blue']);
+		$result = (string) $this->form->select('color')->options(['red' => 'Red', 'blue' => 'Blue']);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -319,7 +319,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected .= '<option value="tofu">Tofu</option>';
 		$expected .= '<option value="chips" selected>Chips</option>';
 		$expected .= '</select>';
-		$result = (string)$this->form->select('favourite_foods', ['fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'])->multiple();
+		$result = (string) $this->form->select('favourite_foods', ['fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'])->multiple();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -332,7 +332,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<textarea name="bio" rows="10" cols="50">This is my bio</textarea>';
-		$result = (string)$this->form->textarea('bio');
+		$result = (string) $this->form->textarea('bio');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -345,14 +345,14 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<textarea name="bio" rows="10" cols="50">&lt;script&gt;alert(&quot;xss!&quot;);&lt;/script&gt;</textarea>';
-		$result = (string)$this->form->textarea('bio');
+		$result = (string) $this->form->textarea('bio');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testNoErrorStoreReturnsNull()
 	{
 		$expected = '';
-		$result = (string)$this->form->getError('email');
+		$result = (string) $this->form->getError('email');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -416,44 +416,44 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testHidden()
 	{
 		$expected = '<input type="hidden" name="secret">';
-		$result = (string)$this->form->hidden('secret');
+		$result = (string) $this->form->hidden('secret');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="hidden" name="token">';
-		$result = (string)$this->form->hidden('token');
+		$result = (string) $this->form->hidden('token');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testFile()
 	{
 		$expected = '<input type="file" name="photo">';
-		$result = (string)$this->form->file('photo');
+		$result = (string) $this->form->file('photo');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="file" name="document">';
-		$result = (string)$this->form->file('document');
+		$result = (string) $this->form->file('document');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testDate()
 	{
 		$expected = '<input type="date" name="date_of_birth">';
-		$result = (string)$this->form->date('date_of_birth');
+		$result = (string) $this->form->date('date_of_birth');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="date" name="start_date">';
-		$result = (string)$this->form->date('start_date');
+		$result = (string) $this->form->date('start_date');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testEmail()
 	{
 		$expected = '<input type="email" name="email">';
-		$result = (string)$this->form->email('email');
+		$result = (string) $this->form->email('email');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="email" name="alternate_email">';
-		$result = (string)$this->form->email('alternate_email');
+		$result = (string) $this->form->email('alternate_email');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -466,7 +466,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="date" name="date_of_birth" value="1999-04-06">';
-		$result = (string)$this->form->date('date_of_birth');
+		$result = (string) $this->form->date('date_of_birth');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -479,7 +479,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="email" name="email" value="example@example.com">';
-		$result = (string)$this->form->email('email');
+		$result = (string) $this->form->email('email');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -492,7 +492,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<input type="hidden" name="secret" value="my-secret-string">';
-		$result = (string)$this->form->hidden('secret');
+		$result = (string) $this->form->hidden('secret');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -506,7 +506,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setToken('12345');
 
 		$expected = '<input type="hidden" name="_token" value="12345">';
-		$result = (string)$this->form->token();
+		$result = (string) $this->form->token();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -514,7 +514,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$this->form->setToken('12345');
 		$expected = '<form method="POST" action=""><input type="hidden" name="_token" value="12345">';
-		$result = (string)$this->form->open();
+		$result = (string) $this->form->open();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -522,14 +522,14 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$this->form->setToken('12345');
 		$expected = '<form method="GET" action="">';
-		$result = (string)$this->form->open()->get();
+		$result = (string) $this->form->open()->get();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testSelectMonth()
 	{
 		$expected = '<select name="month"><option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option value="10">October</option><option value="11">November</option><option value="12">December</option></select>';
-		$result = (string)$this->form->selectMonth('month');
+		$result = (string) $this->form->selectMonth('month');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -543,7 +543,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="email" name="email" value="johndoe@example.com">';
-		$result = (string)$this->form->email('email');
+		$result = (string) $this->form->email('email');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -552,7 +552,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="text" name="first_name" value="John">';
-		$result = (string)$this->form->text('first_name');
+		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -561,7 +561,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="text" name="number" value="0">';
-		$result = (string)$this->form->text('number');
+		$result = (string) $this->form->text('number');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -570,7 +570,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="date" name="date_of_birth" value="1985-05-06">';
-		$result = (string)$this->form->date('date_of_birth');
+		$result = (string) $this->form->date('date_of_birth');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -579,7 +579,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<select name="gender"><option value="male" selected>Male</option><option value="female">Female</option></select>';
-		$result = (string)$this->form->select('gender', ['male' => 'Male', 'female' => 'Female']);
+		$result = (string) $this->form->select('gender', ['male' => 'Male', 'female' => 'Female']);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -593,7 +593,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected .= '<option value="tofu">Tofu</option>';
 		$expected .= '<option value="chips" selected>Chips</option>';
 		$expected .= '</select>';
-		$result = (string)$this->form->select('favourite_foods', ['fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'])->multiple();
+		$result = (string) $this->form->select('favourite_foods', ['fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'])->multiple();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -602,7 +602,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="hidden" name="last_name" value="Doe">';
-		$result = (string)$this->form->hidden('last_name');
+		$result = (string) $this->form->hidden('last_name');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -616,7 +616,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="text" name="first_name" value="Steve">';
-		$result = (string)$this->form->text('first_name');
+		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -625,7 +625,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
-		$result = (string)$this->form->checkbox('terms', 'agree');
+		$result = (string) $this->form->checkbox('terms', 'agree');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -635,15 +635,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->bind($object);
 
 		$expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked="checked">';
-		$result = (string)$this->form->checkbox('favourite_foods[]', 'fish');
+		$result = (string) $this->form->checkbox('favourite_foods[]', 'fish');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="checkbox" name="favourite_foods[]" value="tofu">';
-		$result = (string)$this->form->checkbox('favourite_foods[]', 'tofu');
+		$result = (string) $this->form->checkbox('favourite_foods[]', 'tofu');
 		$this->assertEquals($expected, $result);
 
 		$expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked="checked">';
-		$result = (string)$this->form->checkbox('favourite_foods[]', 'chips');
+		$result = (string) $this->form->checkbox('favourite_foods[]', 'chips');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -652,7 +652,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="text" name="first_name" value="Mike">';
-		$result = (string)$this->form->text('first_name')->value('Mike');
+		$result = (string) $this->form->text('first_name')->value('Mike');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -661,7 +661,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="radio" name="terms" value="agree">';
-		$result = (string)$this->form->radio('terms', 'agree')->uncheck();
+		$result = (string) $this->form->radio('terms', 'agree')->uncheck();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -670,7 +670,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="radio" name="color" value="green">';
-		$result = (string)$this->form->radio('color', 'green')->uncheck();
+		$result = (string) $this->form->radio('color', 'green')->uncheck();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -679,7 +679,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="radio" name="terms" value="agree" checked="checked">';
-		$result = (string)$this->form->radio('terms', 'agree')->check();
+		$result = (string) $this->form->radio('terms', 'agree')->check();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -688,7 +688,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="radio" name="color" value="green" checked="checked">';
-		$result = (string)$this->form->radio('color', 'green')->check();
+		$result = (string) $this->form->radio('color', 'green')->check();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -697,7 +697,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<input type="text" name="not_set">';
-		$result = (string)$this->form->text('not_set');
+		$result = (string) $this->form->text('not_set');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -706,7 +706,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = new MagicGetter;
 		$this->form->bind($object);
 		$expected = '<input type="text" name="not_set" value="foo">';
-		$result = (string)$this->form->text('not_set');
+		$result = (string) $this->form->text('not_set');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -715,7 +715,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$model = ['first_name' => 'John'];
 		$this->form->bind($model);
 		$expected = '<input type="text" name="first_name" value="John">';
-		$result = (string)$this->form->text('first_name');
+		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -725,7 +725,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->bind($object);
 		$this->form->close();
 		$expected = '<input type="text" name="first_name">';
-		$result = (string)$this->form->text('first_name');
+		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -735,14 +735,14 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object->first_name = '" onmouseover="alert(\'xss\')';
 		$this->form->bind($object);
 		$expected = '<input type="text" name="first_name" value="&quot; onmouseover=&quot;alert(&#039;xss&#039;)">';
-		$result = (string)$this->form->text('first_name');
+		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRemoveClass()
 	{
 		$expected = '<input type="text" name="food">';
-		$result = (string)$this->form->text('food')->addClass('sandwich pizza')->removeClass('sandwich')->removeClass('pizza');
+		$result = (string) $this->form->text('food')->addClass('sandwich pizza')->removeClass('sandwich')->removeClass('pizza');
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -103,20 +103,20 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 	public function buttonProvider()
 	{
-		return array(
-			array('Click Me', 'click-me', '<button type="button" name="click-me">Click Me</button>'),
-			array('Click Me', null, '<button type="button">Click Me</button>')
-		);
+		return [
+			['Click Me', 'click-me', '<button type="button" name="click-me">Click Me</button>'],
+			['Click Me', null, '<button type="button">Click Me</button>'],
+		];
 	}
 
 	public function testSelect()
 	{
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue">Blue</option></select>';
-		$result = (string)$this->form->select('color', array('red' => 'Red', 'blue' => 'Blue'));
+		$result = (string)$this->form->select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$this->assertEquals($expected, $result);
 
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry">Blueberry</option></select>';
-		$result = (string)$this->form->select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$result = (string)$this->form->select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -176,7 +176,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
 		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
-		$oldInput->shouldReceive('getOldInput')->with('favourite_foods')->andReturn(array(0 => 'fish', 1 => 'chips'));
+		$oldInput->shouldReceive('getOldInput')->with('favourite_foods')->andReturn(['fish', 'chips']);
 
 		$this->form->setOldInputProvider($oldInput);
 
@@ -298,11 +298,11 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->setOldInputProvider($oldInput);
 
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
-		$result = (string)$this->form->select('color', array('red' => 'Red', 'blue' => 'Blue'));
+		$result = (string)$this->form->select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$this->assertEquals($expected, $result);
 
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
-		$result = (string)$this->form->select('color')->options(array('red' => 'Red', 'blue' => 'Blue'));
+		$result = (string)$this->form->select('color')->options(['red' => 'Red', 'blue' => 'Blue']);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -310,7 +310,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
 	    $oldInput->shouldReceive('hasOldInput')->andReturn(true);
-	    $oldInput->shouldReceive('getOldInput')->with('favourite_foods')->andReturn(array(0 => 'fish', 1 => 'chips'));
+	    $oldInput->shouldReceive('getOldInput')->with('favourite_foods')->andReturn(['fish', 'chips']);
 
 	    $this->form->setOldInputProvider($oldInput);
 
@@ -319,7 +319,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected .= '<option value="tofu">Tofu</option>';
 		$expected .= '<option value="chips" selected>Chips</option>';
 		$expected .= '</select>';
-		$result = (string)$this->form->select('favourite_foods', array('fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'))->multiple();
+		$result = (string)$this->form->select('favourite_foods', ['fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'])->multiple();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -579,7 +579,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<select name="gender"><option value="male" selected>Male</option><option value="female">Female</option></select>';
-		$result = (string)$this->form->select('gender', array('male' => 'Male', 'female' => 'Female'));
+		$result = (string)$this->form->select('gender', ['male' => 'Male', 'female' => 'Female']);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -593,7 +593,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected .= '<option value="tofu">Tofu</option>';
 		$expected .= '<option value="chips" selected>Chips</option>';
 		$expected .= '</select>';
-		$result = (string)$this->form->select('favourite_foods', array('fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'))->multiple();
+		$result = (string)$this->form->select('favourite_foods', ['fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'])->multiple();
 		$this->assertEquals($expected, $result);
 	}
 
@@ -712,7 +712,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 	public function testBindArray()
 	{
-		$model = array('first_name' => 'John');
+		$model = ['first_name' => 'John'];
 		$this->form->bind($model);
 		$expected = '<input type="text" name="first_name" value="John">';
 		$result = (string)$this->form->text('first_name');
@@ -764,7 +764,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$obj->terms = 'agree';
 		$obj->color = 'green';
 		$obj->number = '0';
-		$obj->favourite_foods = array('fish', 'chips');
+		$obj->favourite_foods = ['fish', 'chips'];
 		return $obj;
 	}
 }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -172,6 +172,27 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderCheckboxArrayWithOldInput()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('favourite_foods')->andReturn(array(0 => 'fish', 1 => 'chips'));
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked="checked">';
+		$result = (string)$this->form->checkbox('favourite_foods[]', 'fish');
+		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="checkbox" name="favourite_foods[]" value="tofu">';
+		$result = (string)$this->form->checkbox('favourite_foods[]', 'tofu');
+		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked="checked">';
+		$result = (string)$this->form->checkbox('favourite_foods[]', 'chips');
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderRadioWithOldInput()
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
@@ -592,6 +613,24 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->form->bind($object);
 		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
 		$result = (string)$this->form->checkbox('terms', 'agree');
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testBindCheckboxArray()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+
+		$expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked="checked">';
+		$result = (string)$this->form->checkbox('favourite_foods[]', 'fish');
+		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="checkbox" name="favourite_foods[]" value="tofu">';
+		$result = (string)$this->form->checkbox('favourite_foods[]', 'tofu');
+		$this->assertEquals($expected, $result);
+
+		$expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked="checked">';
+		$result = (string)$this->form->checkbox('favourite_foods[]', 'chips');
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -272,6 +272,23 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderMultipleSelectWithOldInput()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+	    $oldInput->shouldReceive('hasOldInput')->andReturn(true);
+	    $oldInput->shouldReceive('getOldInput')->with('favourite_foods')->andReturn(array(0 => 'fish', 1 => 'chips'));
+
+	    $this->form->setOldInputProvider($oldInput);
+
+		$expected  = '<select name="favourite_foods[]" multiple="multiple">';
+		$expected .= '<option value="fish" selected>Fish</option>';
+		$expected .= '<option value="tofu">Tofu</option>';
+		$expected .= '<option value="chips" selected>Chips</option>';
+		$expected .= '</select>';
+		$result = (string)$this->form->select('favourite_foods', array('fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'))->multiple();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderTextAreaWithOldInput()
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
@@ -532,6 +549,20 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testBindMultipleSelect()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+
+		$expected  = '<select name="favourite_foods[]" multiple="multiple">';
+		$expected .= '<option value="fish" selected>Fish</option>';
+		$expected .= '<option value="tofu">Tofu</option>';
+		$expected .= '<option value="chips" selected>Chips</option>';
+		$expected .= '</select>';
+		$result = (string)$this->form->select('favourite_foods', array('fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'))->multiple();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testBindHidden()
 	{
 		$object = $this->getStubObject();
@@ -681,6 +712,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$obj->terms = 'agree';
 		$obj->color = 'green';
 		$obj->number = '0';
+		$obj->favourite_foods = array('fish', 'chips');
 		return $obj;
 	}
 }

--- a/tests/FormOpenTest.php
+++ b/tests/FormOpenTest.php
@@ -112,7 +112,7 @@ class FormOpenTest extends PHPUnit_Framework_TestCase
 	{
 		$open = new FormOpen;
 		$expected = '<form method="POST" action=""><input type="hidden" name="_token" value="abc123">';
-		$result = (string)$open->token('abc123');
+		$result = (string) $open->token('abc123');
 
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/IlluminateErrorStoreTest.php
+++ b/tests/IlluminateErrorStoreTest.php
@@ -7,9 +7,7 @@ class IlluminateErrorStoreTest extends PHPUnit_Framework_TestCase
 {
     public function test_it_converts_array_keys_to_dot_notation()
     {
-        $errors = new MessageBag([
-            'foo.bar' => 'Some error',
-        ]);
+        $errors = new MessageBag(['foo.bar' => 'Some error']);
         $session = Mockery::mock('Illuminate\Session\Store');
         $session->shouldReceive('has')->with('errors')->andReturn(true);
         $session->shouldReceive('get')->with('errors')->andReturn($errors);

--- a/tests/IlluminateErrorStoreTest.php
+++ b/tests/IlluminateErrorStoreTest.php
@@ -7,9 +7,9 @@ class IlluminateErrorStoreTest extends PHPUnit_Framework_TestCase
 {
     public function test_it_converts_array_keys_to_dot_notation()
     {
-        $errors = new MessageBag(array(
+        $errors = new MessageBag([
             'foo.bar' => 'Some error',
-        ));
+        ]);
         $session = Mockery::mock('Illuminate\Session\Store');
         $session->shouldReceive('has')->with('errors')->andReturn(true);
         $session->shouldReceive('get')->with('errors')->andReturn($errors);

--- a/tests/InputContractTest.php
+++ b/tests/InputContractTest.php
@@ -119,7 +119,7 @@ trait InputContractTest
         $text = $this->newTestSubjectInstance('email');
 
         $expected = $text->render();
-        $result = (string)$text;
+        $result = (string) $text;
         $message = 'Casting input element to string should return the rendered element';
         $this->assertEquals($expected, $result, $message);
     }

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -21,13 +21,13 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testSelectCanBeCreatedWithOptions()
 	{
-		$select = new Select('birth_year', array(1990, 1991, 1992));
+		$select = new Select('birth_year', [1990, 1991, 1992]);
 		$expected = '<select name="birth_year"><option value="0">1990</option><option value="1">1991</option><option value="2">1992</option></select>';
 		$result = $select->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('birth_year', array(2001, 2002, 2003));
+		$select = new Select('birth_year', [2001, 2002, 2003]);
 		$expected = '<select name="birth_year"><option value="0">2001</option><option value="1">2002</option><option value="2">2003</option></select>';
 		$result = $select->render();
 
@@ -36,13 +36,13 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testSelectCanBeCreatedWithKeyValueOptions()
 	{
-		$select = new Select('color', array('red' => 'Red', 'blue' => 'Blue'));
+		$select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue">Blue</option></select>';
 		$result = $select->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry">Blueberry</option></select>';
 		$result = $select->render();
 
@@ -51,14 +51,14 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testCanAddOption()
 	{
-		$select = new Select('color', array('red' => 'Red'));
+		$select = new Select('color', ['red' => 'Red']);
 		$select->addOption('blue', 'Blue');
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue">Blue</option></select>';
 		$result = $select->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith']);
 		$select->addOption('berry', 'Blueberry');
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry">Blueberry</option></select>';
 		$result = $select->render();
@@ -69,14 +69,14 @@ class SelectTest extends PHPUnit_Framework_TestCase
 	public function testCanSetOptions()
 	{
 		$select = new Select('color');
-		$select->options(array('red' => 'Red', 'blue' => 'Blue'));
+		$select->options(['red' => 'Red', 'blue' => 'Blue']);
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue">Blue</option></select>';
 		$result = $select->render();
 
 		$this->assertEquals($expected, $result);
 
 		$select = new Select('fruit');
-		$select->options(array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select->options(['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry">Blueberry</option></select>';
 		$result = $select->render();
 
@@ -86,14 +86,14 @@ class SelectTest extends PHPUnit_Framework_TestCase
 	public function testCanSetSelectedOption()
 	{
 		$select = new Select('color');
-		$select->options(array('red' => 'Red', 'blue' => 'Blue'));
+		$select->options(['red' => 'Red', 'blue' => 'Blue']);
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
 		$result = $select->select('blue')->render();
 
 		$this->assertEquals($expected, $result);
 
 		$select = new Select('fruit');
-		$select->options(array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select->options(['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple" selected>Granny Smith</option><option value="berry">Blueberry</option></select>';
 		$result = $select->select('apple')->render();
 
@@ -103,14 +103,14 @@ class SelectTest extends PHPUnit_Framework_TestCase
 	public function testCanSelectNumericKeys()
 	{
 		$select = new Select('fruit');
-		$select->options(array('1' => 'Granny Smith', '2' => 'Blueberry'));
+		$select->options(['1' => 'Granny Smith', '2' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="1" selected>Granny Smith</option><option value="2">Blueberry</option></select>';
 		$result = $select->select('1')->render();
 
 		$this->assertEquals($expected, $result);
 
 		$select = new Select('fruit');
-		$select->options(array('1' => 'Granny Smith', '2' => 'Blueberry'));
+		$select->options(['1' => 'Granny Smith', '2' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="1">Granny Smith</option><option value="2" selected>Blueberry</option></select>';
 		$result = $select->select('2')->render();
 
@@ -119,25 +119,25 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testCanSetDefaultOption()
 	{
-		$select = new Select('color', array('red' => 'Red', 'blue' => 'Blue'));
+		$select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$expected = '<select name="color"><option value="red">Red</option><option value="blue" selected>Blue</option></select>';
 		$result = $select->defaultValue('blue')->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple" selected>Granny Smith</option><option value="berry">Blueberry</option></select>';
 		$result = $select->defaultValue('apple')->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry" selected>Blueberry</option></select>';
 		$result = $select->select('berry')->defaultValue('apple')->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry" selected>Blueberry</option></select>';
 		$result = $select->defaultValue('apple')->select('berry')->render();
 
@@ -146,43 +146,43 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testCanSetDefaultOptionMultiselect()
 	{
-		$select = new Select('color', array('red' => 'Red', 'blue' => 'Blue'));
+		$select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$expected = '<select name="color"><option value="red" selected>Red</option><option value="blue" selected>Blue</option></select>';
-		$result = $select->defaultValue(array('blue', 'red'))->render();
+		$result = $select->defaultValue(['blue', 'red'])->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple" selected>Granny Smith</option><option value="berry">Blueberry</option></select>';
-		$result = $select->defaultValue(array('apple'))->render();
+		$result = $select->defaultValue(['apple'])->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry" selected>Blueberry</option></select>';
-		$result = $select->select('berry')->defaultValue(array('apple', 'berry'))->render();
+		$result = $select->select('berry')->defaultValue(['apple', 'berry'])->render();
 
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('apple' => 'Granny Smith', 'berry' => 'Blueberry'));
+		$select = new Select('fruit', ['apple' => 'Granny Smith', 'berry' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="apple">Granny Smith</option><option value="berry" selected>Blueberry</option></select>';
-		$result = $select->defaultValue('apple')->select(array('berry'))->render();
+		$result = $select->defaultValue('apple')->select(['berry'])->render();
 
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testCanUseNestedOptions()
 	{
-		$options = array(
-			'Ontario' => array(
+		$options = [
+			'Ontario' => [
 				'toronto' => 'Toronto',
 				'london' => 'London',
-				),
-			'Quebec' => array(
+			],
+			'Quebec' => [
 				'montreal' => 'Montreal',
 				'quebec-city' => 'Quebec City',
-				),
-			);
+			],
+		];
 		$select = new Select('color', $options);
 		$expected = '<select name="color"><optgroup label="Ontario"><option value="toronto">Toronto</option><option value="london">London</option></optgroup><optgroup label="Quebec"><option value="montreal">Montreal</option><option value="quebec-city">Quebec City</option></optgroup></select>';
 		$result = $select->render();
@@ -192,16 +192,16 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testCanUseNestedOptionsWithoutKeys()
 	{
-		$options = array(
-			'Ontario' => array(
+		$options = [
+			'Ontario' => [
 				'Toronto',
 				'London',
-				),
-			'Quebec' => array(
+			],
+			'Quebec' => [
 				'Montreal',
 				'Quebec City',
-				),
-			);
+			],
+		];
 		$select = new Select('color', $options);
 		$expected = '<select name="color"><optgroup label="Ontario"><option value="0">Toronto</option><option value="1">London</option></optgroup><optgroup label="Quebec"><option value="0">Montreal</option><option value="1">Quebec City</option></optgroup></select>';
 		$result = $select->render();
@@ -211,14 +211,14 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testCanMixNestedAndUnnestedOptions()
 	{
-		$options = array(
+		$options = [
 			'toronto' => 'Toronto',
 			'london' => 'London',
-			'Quebec' => array(
+			'Quebec' => [
 				'montreal' => 'Montreal',
 				'quebec-city' => 'Quebec City',
-				),
-			);
+			],
+		];
 		$select = new Select('color', $options);
 		$expected = '<select name="color"><option value="toronto">Toronto</option><option value="london">London</option><optgroup label="Quebec"><option value="montreal">Montreal</option><option value="quebec-city">Quebec City</option></optgroup></select>';
 		$result = $select->render();
@@ -228,12 +228,12 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testSelectCanBeCreatedWithIntegerKeyValueOptions()
 	{
-		$select = new Select('color', array('0' => 'Red', '1' => 'Blue'));
+		$select = new Select('color', ['0' => 'Red', '1' => 'Blue']);
 		$expected = '<select name="color"><option value="0">Red</option><option value="1">Blue</option></select>';
 		$result = $select->render();
 		$this->assertEquals($expected, $result);
 
-		$select = new Select('fruit', array('1' => 'Granny Smith', '0' => 'Blueberry'));
+		$select = new Select('fruit', ['1' => 'Granny Smith', '0' => 'Blueberry']);
 		$expected = '<select name="fruit"><option value="1">Granny Smith</option><option value="0">Blueberry</option></select>';
 		$result = $select->render();
 		$this->assertEquals($expected, $result);
@@ -256,9 +256,9 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
 	public function testCanSelectMultipleElementsInMultiselects()
 	{
-		$select = new Select('color', array('red' => 'Red', 'blue' => 'Blue'));
+		$select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
 		$expected = '<select name="color[]" multiple="multiple"><option value="red" selected>Red</option><option value="blue" selected>Blue</option></select>';
-		$result = $select->multiple()->select(array('red', 'blue'))->render();
+		$result = $select->multiple()->select(['red', 'blue'])->render();
 
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
Old input and model binding worked fine multiple selects (this PR adds test coverage to prove this):
```php
$form->select('favourite_foods[]')
     ->options(['fish' => 'Fish', 'tofu' => 'Tofu', 'chips' => 'Chips'])
     ->multiple()
```

But doesn't work on checkbox arrays:
```php
$form->checkbox('favourite_foods[]', 'fish')
$form->checkbox('favourite_foods[]', 'tofu')
$form->checkbox('favourite_foods[]', 'chips')
```

This PR adds test coverage and a proposed fix for checkbox array old input and model binding.