### PR TITLE
Fix defaultToChecked() and defaultToUnchecked() precedence.

### DIFF
--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -13,6 +13,7 @@ class Checkbox extends Input
     public function __construct($name, $value = 1)
     {
         parent::__construct($name);
+
         $this->setValue($value);
     }
 
@@ -28,7 +29,7 @@ class Checkbox extends Input
 
     public function defaultToChecked()
     {
-        if (! isset($this->checked)) {
+        if (! isset($this->checked) && is_null($this->oldValue)) {
             $this->check();
         }
 
@@ -37,7 +38,7 @@ class Checkbox extends Input
 
     public function defaultToUnchecked()
     {
-        if (! isset($this->checked)) {
+        if (! isset($this->checked) && is_null($this->oldValue)) {
             $this->uncheck();
         }
 
@@ -47,6 +48,7 @@ class Checkbox extends Input
     public function defaultCheckedState($state)
     {
         $state ? $this->defaultToChecked() : $this->defaultToUnchecked();
+
         return $this;
     }
 
@@ -54,6 +56,7 @@ class Checkbox extends Input
     {
         $this->unsetOldValue();
         $this->setChecked(true);
+
         return $this;
     }
 
@@ -61,6 +64,7 @@ class Checkbox extends Input
     {
         $this->unsetOldValue();
         $this->setChecked(false);
+
         return $this;
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -262,6 +262,58 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+    public function testOldInputOnCheckboxTakesPrecedenceOverDefaultToChecked()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('published')->andReturn('0');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="checkbox" name="published" value="1">';
+		$result = (string) $this->form->checkbox('published', 1)->defaultToChecked();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testOldInputOnCheckboxTakesPrecedenceOverDefaultToUnchecked()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('published')->andReturn('1');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="checkbox" name="published" value="1" checked="checked">';
+		$result = (string) $this->form->checkbox('published', 1)->defaultToUnchecked();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testOldInputOnRadioTakesPrecedenceOverDefaultToChecked()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('published')->andReturn('0');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="radio" name="published" value="1">';
+		$result = (string) $this->form->radio('published', 1)->defaultToChecked();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testOldInputOnRadioTakesPrecedenceOverDefaultToUnchecked()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->with('published')->andReturn('1');
+
+		$this->form->setOldInputProvider($oldInput);
+
+		$expected = '<input type="radio" name="published" value="1" checked="checked">';
+		$result = (string) $this->form->radio('published', 1)->defaultToUnchecked();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderCheckboxAgainstBinaryZero()
 	{
 		$expected = '<input type="checkbox" name="boolean" value="0">';
@@ -513,6 +565,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testTokenIsRenderedAutomaticallyOnOpenIfSet()
 	{
 		$this->form->setToken('12345');
+
 		$expected = '<form method="POST" action=""><input type="hidden" name="_token" value="12345">';
 		$result = (string) $this->form->open();
 		$this->assertEquals($expected, $result);
@@ -521,6 +574,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testTokenIsNotRenderedAutomaticallyOnOpenFormWithGetMethodIfSet()
 	{
 		$this->form->setToken('12345');
+
 		$expected = '<form method="GET" action="">';
 		$result = (string) $this->form->open()->get();
 		$this->assertEquals($expected, $result);
@@ -542,6 +596,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="email" name="email" value="johndoe@example.com">';
 		$result = (string) $this->form->email('email');
 		$this->assertEquals($expected, $result);
@@ -551,6 +606,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="text" name="first_name" value="John">';
 		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
@@ -560,6 +616,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="text" name="number" value="0">';
 		$result = (string) $this->form->text('number');
 		$this->assertEquals($expected, $result);
@@ -569,6 +626,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="date" name="date_of_birth" value="1985-05-06">';
 		$result = (string) $this->form->date('date_of_birth');
 		$this->assertEquals($expected, $result);
@@ -578,6 +636,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<select name="gender"><option value="male" selected>Male</option><option value="female">Female</option></select>';
 		$result = (string) $this->form->select('gender', ['male' => 'Male', 'female' => 'Female']);
 		$this->assertEquals($expected, $result);
@@ -601,6 +660,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="hidden" name="last_name" value="Doe">';
 		$result = (string) $this->form->hidden('last_name');
 		$this->assertEquals($expected, $result);
@@ -615,6 +675,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="text" name="first_name" value="Steve">';
 		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
@@ -624,6 +685,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
 		$result = (string) $this->form->checkbox('terms', 'agree');
 		$this->assertEquals($expected, $result);
@@ -651,6 +713,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="text" name="first_name" value="Mike">';
 		$result = (string) $this->form->text('first_name')->value('Mike');
 		$this->assertEquals($expected, $result);
@@ -660,6 +723,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="radio" name="terms" value="agree">';
 		$result = (string) $this->form->radio('terms', 'agree')->uncheck();
 		$this->assertEquals($expected, $result);
@@ -669,6 +733,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="radio" name="color" value="green">';
 		$result = (string) $this->form->radio('color', 'green')->uncheck();
 		$this->assertEquals($expected, $result);
@@ -678,6 +743,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="radio" name="terms" value="agree" checked="checked">';
 		$result = (string) $this->form->radio('terms', 'agree')->check();
 		$this->assertEquals($expected, $result);
@@ -687,8 +753,57 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="radio" name="color" value="green" checked="checked">';
 		$result = (string) $this->form->radio('color', 'green')->check();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testBindingOnCheckboxTakesPrecedenceOverDefaultToChecked()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+
+		$expected  = '<input type="checkbox" name="published[]" value="1" checked="checked">';
+		$expected .= '<input type="checkbox" name="published[]" value="0">';
+		$result  = (string) $this->form->checkbox('published[]', 1);
+		$result .= (string) $this->form->checkbox('published[]', 0)->defaultToChecked();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testBindingOnCheckboxTakesPrecedenceOverDefaultToUnchecked()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+
+		$expected  = '<input type="checkbox" name="published[]" value="1" checked="checked">';
+		$expected .= '<input type="checkbox" name="published[]" value="0">';
+		$result  = (string) $this->form->checkbox('published[]', 1)->defaultToUnchecked();
+		$result .= (string) $this->form->checkbox('published[]', 0);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testBindingOnRadioTakesPrecedenceOverDefaultToChecked()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+
+		$expected  = '<input type="radio" name="published[]" value="1" checked="checked">';
+		$expected .= '<input type="radio" name="published[]" value="0">';
+		$result  = (string) $this->form->radio('published[]', 1);
+		$result .= (string) $this->form->radio('published[]', 0)->defaultToChecked();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testBindingOnRadioTakesPrecedenceOverDefaultToUnchecked()
+	{
+		$object = $this->getStubObject();
+		$this->form->bind($object);
+
+		$expected  = '<input type="radio" name="published[]" value="1" checked="checked">';
+		$expected .= '<input type="radio" name="published[]" value="0">';
+		$result  = (string) $this->form->radio('published[]', 1)->defaultToUnchecked();
+		$result .= (string) $this->form->radio('published[]', 0);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -696,6 +811,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = $this->getStubObject();
 		$this->form->bind($object);
+
 		$expected = '<input type="text" name="not_set">';
 		$result = (string) $this->form->text('not_set');
 		$this->assertEquals($expected, $result);
@@ -705,6 +821,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$object = new MagicGetter;
 		$this->form->bind($object);
+
 		$expected = '<input type="text" name="not_set" value="foo">';
 		$result = (string) $this->form->text('not_set');
 		$this->assertEquals($expected, $result);
@@ -714,6 +831,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$model = ['first_name' => 'John'];
 		$this->form->bind($model);
+
 		$expected = '<input type="text" name="first_name" value="John">';
 		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
@@ -724,6 +842,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$this->form->close();
+
 		$expected = '<input type="text" name="first_name">';
 		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
@@ -734,6 +853,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$object->first_name = '" onmouseover="alert(\'xss\')';
 		$this->form->bind($object);
+
 		$expected = '<input type="text" name="first_name" value="&quot; onmouseover=&quot;alert(&#039;xss&#039;)">';
 		$result = (string) $this->form->text('first_name');
 		$this->assertEquals($expected, $result);
@@ -765,6 +885,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 		$obj->color = 'green';
 		$obj->number = '0';
 		$obj->favourite_foods = ['fish', 'chips'];
+		$obj->published = '1';
 		return $obj;
 	}
 }


### PR DESCRIPTION
Fix defaultToChecked() and defaultToUnchecked() precedence over old input and binding.