### PR TITLE
Add readonly() attribute setter, akin to disabled(), autofocus(), etc.

### DIFF
--- a/src/AdamWathan/Form/Elements/FormControl.php
+++ b/src/AdamWathan/Form/Elements/FormControl.php
@@ -35,9 +35,17 @@ abstract class FormControl extends Element
         return $this;
     }
 
+    public function readonly()
+    {
+        $this->setAttribute('readonly', 'readonly');
+
+        return $this;
+    }
+
     public function enable()
     {
         $this->removeAttribute('disabled');
+        $this->removeAttribute('readonly');
 
         return $this;
     }

--- a/tests/InputContractTest.php
+++ b/tests/InputContractTest.php
@@ -77,7 +77,16 @@ trait InputContractTest
         $this->assertRegExp($this->elementRegExp('disabled="disabled"'), $result, $message);
     }
 
-    public function testEnable()
+    public function testReadyOnly()
+    {
+        $text = $this->newTestSubjectInstance('email');
+        $result = $text->readonly()->render();
+
+        $message = 'readonly attribute should be set';
+        $this->assertRegExp($this->elementRegExp('readonly="readonly"'), $result, $message);
+    }
+
+    public function testEnableDisabled()
     {
         $pattern = 'disabled="disabled"';
 
@@ -92,6 +101,23 @@ trait InputContractTest
 
         $message = 'disabled attribute should not be removed';
         $this->assertNotRegExp($this->elementRegExp('disabled="disabled"'), $result, $message);
+    }
+
+    public function testEnableReadOnly()
+    {
+        $pattern = 'readonly="readonly"';
+
+        $text = $this->newTestSubjectInstance('email');
+        $result = $text->enable()->render();
+
+        $message = 'readonly attribute should not be set';
+        $this->assertNotRegExp($this->elementRegExp($pattern), $result, $message);
+
+        $text = $this->newTestSubjectInstance('email');
+        $result = $text->readonly()->enable()->render();
+
+        $message = 'readonly attribute should not be removed';
+        $this->assertNotRegExp($this->elementRegExp('readonly="readonly"'), $result, $message);
     }
 
     public function testCanBeCastToString()


### PR DESCRIPTION
Add `readonly()` attribute setter, akin to `disable()`, `autofocus()`, etc.

```php
$form->text('title')->readonly();
```

Which would render:
```php
<input type="text" name="title" readonly="readonly">
```

And have `enable()` remove both `disabled` and `readonly` attributes.

PS. Unrelated to this PR, but is there any significant reason why boolean attributes aren't rendered like this?
```php
<input type="text" name="title" autofocus>
<input type="text" name="title" disabled>
<input type="text" name="title" readonly>
```