### PR TITLE
Use HTML5 boolean attribute syntax

### DIFF
--- a/src/AdamWathan/Form/Elements/Checkbox.php
+++ b/src/AdamWathan/Form/Elements/Checkbox.php
@@ -76,7 +76,7 @@ class Checkbox extends Input
         $this->removeAttribute('checked');
 
         if ($checked) {
-            $this->setAttribute('checked', 'checked');
+            $this->setAttribute('checked');
         }
     }
 

--- a/src/AdamWathan/Form/Elements/Element.php
+++ b/src/AdamWathan/Form/Elements/Element.php
@@ -8,10 +8,6 @@ abstract class Element
 
     protected function setAttribute($attribute, $value = null)
     {
-        if (is_null($value)) {
-            return;
-        }
-
         $this->attributes[$attribute] = $value;
     }
 
@@ -38,7 +34,7 @@ abstract class Element
         return $this;
     }
 
-    public function attribute($attribute, $value)
+    public function attribute($attribute, $value = null)
     {
         $this->setAttribute($attribute, $value);
 
@@ -105,14 +101,26 @@ abstract class Element
 
     protected function renderAttributes()
     {
-        return implode(array_map(function ($attribute, $value) {
-            return sprintf(' %s="%s"', $attribute, $value);
-        }, array_keys($this->attributes), $this->attributes));
+        $attributes = array_map(function ($attribute, $value) {
+            return $this->renderAttribute($attribute, $value);
+        }, array_keys($this->attributes), $this->attributes);
+
+        $attributes = array_merge([''], $attributes);
+
+        return implode(' ', $attributes);
+    }
+
+    protected function renderAttribute($attribute, $value = null)
+    {
+        if ($value === null) {
+            return "{$attribute}";
+        }
+
+        return sprintf('%s="%s"', $attribute, $value);
     }
 
     public function __call($method, $params)
     {
-        $params = count($params) ? $params : [$method];
         $params = array_merge([$method], $params);
         call_user_func_array([$this, 'attribute'], $params);
 

--- a/src/AdamWathan/Form/Elements/FormControl.php
+++ b/src/AdamWathan/Form/Elements/FormControl.php
@@ -4,9 +4,11 @@ namespace AdamWathan\Form\Elements;
 
 abstract class FormControl extends Element
 {
-    public function __construct($name)
+    public function __construct($name = null)
     {
-        $this->setName($name);
+        if ($name !== null) {
+            $this->setName($name);
+        }
     }
 
     protected function setName($name)
@@ -16,7 +18,7 @@ abstract class FormControl extends Element
 
     public function required()
     {
-        $this->setAttribute('required', 'required');
+        $this->setAttribute('required');
 
         return $this;
     }
@@ -30,14 +32,14 @@ abstract class FormControl extends Element
 
     public function disable()
     {
-        $this->setAttribute('disabled', 'disabled');
+        $this->setAttribute('disabled');
 
         return $this;
     }
 
     public function readonly()
     {
-        $this->setAttribute('readonly', 'readonly');
+        $this->setAttribute('readonly');
 
         return $this;
     }
@@ -52,7 +54,7 @@ abstract class FormControl extends Element
 
     public function autofocus()
     {
-        $this->setAttribute('autofocus', 'autofocus');
+        $this->setAttribute('autofocus');
 
         return $this;
     }

--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -102,12 +102,13 @@ class Select extends FormControl
     public function multiple()
     {
         $name = $this->attributes['name'];
+
         if (substr($name, -2) != '[]') {
             $name .= '[]';
         }
 
         $this->setName($name);
-        $this->setAttribute('multiple', 'multiple');
+        $this->setAttribute('multiple');
 
         return $this;
     }

--- a/tests/BindingTest.php
+++ b/tests/BindingTest.php
@@ -74,7 +74,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected  = '<select name="favourite_foods[]" multiple="multiple">';
+        $expected  = '<select name="favourite_foods[]" multiple>';
         $expected .= '<option value="fish" selected>Fish</option>';
         $expected .= '<option value="tofu">Tofu</option>';
         $expected .= '<option value="chips" selected>Chips</option>';
@@ -98,7 +98,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
+        $expected = '<input type="checkbox" name="terms" value="agree" checked>';
         $result = (string) $this->form->checkbox('terms', 'agree');
         $this->assertEquals($expected, $result);
     }
@@ -108,7 +108,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked="checked">';
+        $expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked>';
         $result = (string) $this->form->checkbox('favourite_foods[]', 'fish');
         $this->assertEquals($expected, $result);
 
@@ -116,7 +116,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $result = (string) $this->form->checkbox('favourite_foods[]', 'tofu');
         $this->assertEquals($expected, $result);
 
-        $expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked="checked">';
+        $expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked>';
         $result = (string) $this->form->checkbox('favourite_foods[]', 'chips');
         $this->assertEquals($expected, $result);
     }
@@ -188,7 +188,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected  = '<input type="checkbox" name="published[]" value="1" checked="checked">';
+        $expected  = '<input type="checkbox" name="published[]" value="1" checked>';
         $expected .= '<input type="checkbox" name="published[]" value="0">';
         $result  = (string) $this->form->checkbox('published[]', 1);
         $result .= (string) $this->form->checkbox('published[]', 0)->defaultToChecked();
@@ -200,7 +200,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected  = '<input type="checkbox" name="published[]" value="1" checked="checked">';
+        $expected  = '<input type="checkbox" name="published[]" value="1" checked>';
         $expected .= '<input type="checkbox" name="published[]" value="0">';
         $result  = (string) $this->form->checkbox('published[]', 1)->defaultToUnchecked();
         $result .= (string) $this->form->checkbox('published[]', 0);
@@ -212,7 +212,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected  = '<input type="radio" name="published[]" value="1" checked="checked">';
+        $expected  = '<input type="radio" name="published[]" value="1" checked>';
         $expected .= '<input type="radio" name="published[]" value="0">';
         $result  = (string) $this->form->radio('published[]', 1);
         $result .= (string) $this->form->radio('published[]', 0)->defaultToChecked();
@@ -224,7 +224,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected  = '<input type="radio" name="published[]" value="1" checked="checked">';
+        $expected  = '<input type="radio" name="published[]" value="1" checked>';
         $expected .= '<input type="radio" name="published[]" value="0">';
         $result  = (string) $this->form->radio('published[]', 1)->defaultToUnchecked();
         $result .= (string) $this->form->radio('published[]', 0);
@@ -271,7 +271,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected = '<input type="radio" name="terms" value="agree" checked="checked">';
+        $expected = '<input type="radio" name="terms" value="agree" checked>';
         $result = (string) $this->form->radio('terms', 'agree')->check();
         $this->assertEquals($expected, $result);
     }
@@ -281,7 +281,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = $this->getStubObject();
         $this->form->bind($object);
 
-        $expected = '<input type="radio" name="color" value="green" checked="checked">';
+        $expected = '<input type="radio" name="color" value="green" checked>';
         $result = (string) $this->form->radio('color', 'green')->check();
         $this->assertEquals($expected, $result);
     }

--- a/tests/CheckboxTest.php
+++ b/tests/CheckboxTest.php
@@ -24,7 +24,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
     public function testCanCheckCheckbox()
     {
         $checkbox = new Checkbox('terms');
-        $expected = '<input type="checkbox" name="terms" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="terms" value="1" checked>';
         $result = $checkbox->check()->render();
 
         $this->assertEquals($expected, $result);
@@ -42,7 +42,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
     public function testDefaultToChecked()
     {
         $checkbox = new Checkbox('above_18');
-        $expected = '<input type="checkbox" name="above_18" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="above_18" value="1" checked>';
         $result = $checkbox->defaultToChecked()->render();
 
         $this->assertEquals($expected, $result);
@@ -69,13 +69,13 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
 
         $checkbox = new Checkbox('above_18');
-        $expected = '<input type="checkbox" name="above_18" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="above_18" value="1" checked>';
         $result = $checkbox->defaultToUnchecked()->check()->render();
 
         $this->assertEquals($expected, $result);
 
         $checkbox = new Checkbox('above_18');
-        $expected = '<input type="checkbox" name="above_18" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="above_18" value="1" checked>';
         $result = $checkbox->check()->defaultToUnchecked()->render();
 
         $this->assertEquals($expected, $result);
@@ -84,7 +84,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
     public function testDefaultCheckedState()
     {
         $checkbox = new Checkbox('above_18');
-        $expected = '<input type="checkbox" name="above_18" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="above_18" value="1" checked>';
         $result = $checkbox->defaultCheckedState(true)->render();
 
         $this->assertEquals($expected, $result);
@@ -101,7 +101,7 @@ class CheckboxTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
 
         $checkbox = new Checkbox('above_18');
-        $expected = '<input type="checkbox" name="above_18" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="above_18" value="1" checked>';
         $result = $checkbox->check()->defaultCheckedState(false)->render();
 
         $this->assertEquals($expected, $result);

--- a/tests/InputContractTest.php
+++ b/tests/InputContractTest.php
@@ -22,7 +22,7 @@ trait InputContractTest
         $result = $text->required()->render();
 
         $message = "required attribute should be set";
-        $this->assertRegExp($this->elementRegExp('required="required"'), $result, $message);
+        $this->assertRegExp($this->elementRegExp('required'), $result, $message);
     }
 
     public function testAutofocus()
@@ -31,12 +31,12 @@ trait InputContractTest
         $result = $text->autofocus()->render();
 
         $message = "autofocus attribute should be set";
-        $this->assertRegExp($this->elementRegExp('autofocus="autofocus"'), $result, $message);
+        $this->assertRegExp($this->elementRegExp('autofocus'), $result, $message);
     }
 
     public function testUnfocus()
     {
-        $pattern = 'autofocus="autofocus"';
+        $pattern = 'autofocus';
 
         $text = $this->newTestSubjectInstance('');
         $result = $text->unfocus()->render();
@@ -53,7 +53,7 @@ trait InputContractTest
 
     public function testOptional()
     {
-        $pattern = 'required="required"';
+        $pattern = 'required';
 
         $text = $this->newTestSubjectInstance('email');
         $result = $text->optional()->render();
@@ -74,7 +74,7 @@ trait InputContractTest
         $result = $text->disable()->render();
 
         $message = 'disabled attribute should be set';
-        $this->assertRegExp($this->elementRegExp('disabled="disabled"'), $result, $message);
+        $this->assertRegExp($this->elementRegExp('disabled'), $result, $message);
     }
 
     public function testReadyOnly()
@@ -83,12 +83,12 @@ trait InputContractTest
         $result = $text->readonly()->render();
 
         $message = 'readonly attribute should be set';
-        $this->assertRegExp($this->elementRegExp('readonly="readonly"'), $result, $message);
+        $this->assertRegExp($this->elementRegExp('readonly'), $result, $message);
     }
 
     public function testEnableDisabled()
     {
-        $pattern = 'disabled="disabled"';
+        $pattern = 'disabled';
 
         $text = $this->newTestSubjectInstance('email');
         $result = $text->enable()->render();
@@ -99,13 +99,13 @@ trait InputContractTest
         $text = $this->newTestSubjectInstance('email');
         $result = $text->disable()->enable()->render();
 
-        $message = 'disabled attribute should not be removed';
-        $this->assertNotRegExp($this->elementRegExp('disabled="disabled"'), $result, $message);
+        $message = 'disabled attribute should be removed';
+        $this->assertNotRegExp($this->elementRegExp('disabled'), $result, $message);
     }
 
     public function testEnableReadOnly()
     {
-        $pattern = 'readonly="readonly"';
+        $pattern = 'readonly';
 
         $text = $this->newTestSubjectInstance('email');
         $result = $text->enable()->render();
@@ -116,8 +116,8 @@ trait InputContractTest
         $text = $this->newTestSubjectInstance('email');
         $result = $text->readonly()->enable()->render();
 
-        $message = 'readonly attribute should not be removed';
-        $this->assertNotRegExp($this->elementRegExp('readonly="readonly"'), $result, $message);
+        $message = 'readonly attribute should be removed';
+        $this->assertNotRegExp($this->elementRegExp('readonly'), $result, $message);
     }
 
     public function testCanBeCastToString()
@@ -302,6 +302,6 @@ trait InputContractTest
         $result = $text->moo()->render();
 
         $message = 'moo attribute should be set through magic method without parameter';
-        $this->assertRegExp($this->elementRegExp('moo="moo"'), $result, $message);
+        $this->assertRegExp($this->elementRegExp('moo'), $result, $message);
     }
 }

--- a/tests/OldInputTest.php
+++ b/tests/OldInputTest.php
@@ -35,11 +35,11 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
+        $expected = '<input type="checkbox" name="terms" value="agree" checked>';
         $result = (string) $this->form->checkbox('terms', 'agree');
         $this->assertEquals($expected, $result);
 
-        $expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
+        $expected = '<input type="checkbox" name="terms" value="agree" checked>';
         $result = (string) $this->form->checkbox('terms')->value('agree');
         $this->assertEquals($expected, $result);
     }
@@ -52,7 +52,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked="checked">';
+        $expected = '<input type="checkbox" name="favourite_foods[]" value="fish" checked>';
         $result = (string) $this->form->checkbox('favourite_foods[]', 'fish');
         $this->assertEquals($expected, $result);
 
@@ -60,7 +60,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
         $result = (string) $this->form->checkbox('favourite_foods[]', 'tofu');
         $this->assertEquals($expected, $result);
 
-        $expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked="checked">';
+        $expected = '<input type="checkbox" name="favourite_foods[]" value="chips" checked>';
         $result = (string) $this->form->checkbox('favourite_foods[]', 'chips');
         $this->assertEquals($expected, $result);
     }
@@ -73,11 +73,11 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="radio" name="color" value="green" checked="checked">';
+        $expected = '<input type="radio" name="color" value="green" checked>';
         $result = (string) $this->form->radio('color', 'green');
         $this->assertEquals($expected, $result);
 
-        $expected = '<input type="radio" name="color" value="green" checked="checked">';
+        $expected = '<input type="radio" name="color" value="green" checked>';
         $result = (string) $this->form->radio('color')->value('green');
         $this->assertEquals($expected, $result);
     }
@@ -107,7 +107,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected  = '<select name="favourite_foods[]" multiple="multiple">';
+        $expected  = '<select name="favourite_foods[]" multiple>';
         $expected .= '<option value="fish" selected>Fish</option>';
         $expected .= '<option value="tofu">Tofu</option>';
         $expected .= '<option value="chips" selected>Chips</option>';
@@ -189,7 +189,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="checkbox" name="agree_to_terms" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="agree_to_terms" value="1" checked>';
         $result = (string) $this->form->checkbox('agree_to_terms', 1);
         $this->assertEquals($expected, $result);
     }
@@ -215,7 +215,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="checkbox" name="published" value="1" checked="checked">';
+        $expected = '<input type="checkbox" name="published" value="1" checked>';
         $result = (string) $this->form->checkbox('published', 1)->defaultToUnchecked();
         $this->assertEquals($expected, $result);
     }
@@ -241,7 +241,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="radio" name="published" value="1" checked="checked">';
+        $expected = '<input type="radio" name="published" value="1" checked>';
         $result = (string) $this->form->radio('published', 1)->defaultToUnchecked();
         $this->assertEquals($expected, $result);
     }
@@ -280,7 +280,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="checkbox" name="terms" value="agree" checked="checked">';
+        $expected = '<input type="checkbox" name="terms" value="agree" checked>';
         $result = (string) $this->form->checkbox('terms', 'agree')->check();
         $this->assertEquals($expected, $result);
     }
@@ -293,7 +293,7 @@ class OldInputTest extends PHPUnit_Framework_TestCase
 
         $this->form->setOldInputProvider($oldInput);
 
-        $expected = '<input type="radio" name="color" value="green" checked="checked">';
+        $expected = '<input type="radio" name="color" value="green" checked>';
         $result = (string) $this->form->radio('color', 'green')->check();
         $this->assertEquals($expected, $result);
     }

--- a/tests/RadioButtonTest.php
+++ b/tests/RadioButtonTest.php
@@ -19,7 +19,7 @@ class RadioButtonTest extends PHPUnit_Framework_TestCase
     public function testDefaultToChecked()
     {
         $checkbox = new RadioButton('above_18');
-        $expected = '<input type="radio" name="above_18" value="above_18" checked="checked">';
+        $expected = '<input type="radio" name="above_18" value="above_18" checked>';
         $result = $checkbox->defaultToChecked()->render();
 
         $this->assertEquals($expected, $result);
@@ -46,13 +46,13 @@ class RadioButtonTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
 
         $checkbox = new RadioButton('above_18');
-        $expected = '<input type="radio" name="above_18" value="above_18" checked="checked">';
+        $expected = '<input type="radio" name="above_18" value="above_18" checked>';
         $result = $checkbox->defaultToUnchecked()->check()->render();
 
         $this->assertEquals($expected, $result);
 
         $checkbox = new RadioButton('above_18');
-        $expected = '<input type="radio" name="above_18" value="above_18" checked="checked">';
+        $expected = '<input type="radio" name="above_18" value="above_18" checked>';
         $result = $checkbox->check()->defaultToUnchecked()->render();
 
         $this->assertEquals($expected, $result);

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -243,13 +243,13 @@ class SelectTest extends PHPUnit_Framework_TestCase
     public function testSelectCanBeMultiple()
     {
         $select = new Select('people');
-        $expected = '<select name="people[]" multiple="multiple"></select>';
+        $expected = '<select name="people[]" multiple></select>';
         $result = $select->multiple()->render();
 
         $this->assertEquals($expected, $result);
 
         $select = new Select('people[]');
-        $expected = '<select name="people[]" multiple="multiple"></select>';
+        $expected = '<select name="people[]" multiple></select>';
         $result = $select->multiple()->render();
 
         $this->assertEquals($expected, $result);
@@ -258,7 +258,12 @@ class SelectTest extends PHPUnit_Framework_TestCase
     public function testCanSelectMultipleElementsInMultiselects()
     {
         $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
-        $expected = '<select name="color[]" multiple="multiple"><option value="red" selected>Red</option><option value="blue" selected>Blue</option></select>';
+        $expected = implode([
+            '<select name="color[]" multiple>',
+                '<option value="red" selected>Red</option>',
+                '<option value="blue" selected>Blue</option>',
+            '</select>',
+        ]);
         $result = $select->multiple()->select(['red', 'blue'])->render();
 
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Replace attributes like `required="required"` with just `required`.

Possible BC break in that __call no longer sets the value to the same
value as the method/attribute name automatically, instead calls like
`$element->banana()` will just add a `banana` attribute, not
`banana="banana"` like previously.