### PR TITLE
Remove transformKey() from IlluminateOldInputProvider?

### DIFF
--- a/src/AdamWathan/Form/OldInput/IlluminateOldInputProvider.php
+++ b/src/AdamWathan/Form/OldInput/IlluminateOldInputProvider.php
@@ -20,11 +20,6 @@ class IlluminateOldInputProvider implements OldInputInterface
 
     public function getOldInput($key)
     {
-        return $this->session->getOldInput($this->transformKey($key));
-    }
-
-    protected function transformKey($key)
-    {
-        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $key);
+        return $this->session->getOldInput($key);
     }
 }


### PR DESCRIPTION
We were running `transformKey()` on old input twice, which is a problem (see issue #87).

Existing tests pass, but we have no actual IlluminateOldInputProvider test coverage, instead it's mocked everywhere.