### PR TITLE
Support for binding nested array/object/mixed via new BoundData object

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Boring name for a boring package. Builds form HTML with a fluent-ish, hopefully 
 - [Remembering Old Input](#remembering-old-input)
 - [Error Messages](#error-messages)
 - [CSRF Protection](#csrf-protection)
-- [Model Binding](#model-binding)
+- [Data Binding](#data-binding)
 
 <a href="#installation"></a>
 ## Installation
@@ -24,7 +24,7 @@ composer require adamwathan/form
 
 ### Laravel
 
-> This package works great as a replacement Form Builder that was removed in Laravel 5. The API is different but all of the features are there. 
+> This package works great as a replacement Form Builder that was removed in Laravel 5. The API is different but all of the features are there.
 
 If you are using Laravel 4 or 5, you can register the FormServiceProvider to automatically gain access to the Old Input and Error Message functionality.
 
@@ -353,10 +353,10 @@ Assuming you set a CSRF token when instantiating the Formbuilder (or you are usi
 <?= $builder->token(); ?>
 ```
 
-<a href="#model-binding"></a>
-## Model Binding
+<a href="#data-binding"></a>
+## Data Binding
 
-Sometimes you might have a form where all of the fields match properties on some sort of object in your system, and you want the user to be able to edit those properties. Model binding makes this really easy by allowing you to bind a model to your form that will be used to automatically provide all of the default values for your fields.
+Sometimes you might have a form where all of the fields match properties on some sort of object or array in your system, and you want the user to be able to edit that data. Data binding makes this really easy by allowing you to bind an object or array to your form that will be used to automatically provide all of the default values for your fields.
 
 ```php
 $model->first_name = "John";
@@ -375,6 +375,6 @@ $model->date_of_birth = new DateTime('1985-05-06');
 
 > This will work out of the box with Laravel's Eloquent models.
 
-When using model binding, old input will still take priority over any values on your model, so you can still easily redirect the user back to the form with any validation errors without losing any of the data they entered.
+When using data binding, old input will still take priority over any of your bound values, so you can still easily redirect the user back to the form with any validation errors without losing any of the data they entered.
 
 > Note: Be sure to `bind` before creating any other form elements.

--- a/src/AdamWathan/Form/Binding/BoundData.php
+++ b/src/AdamWathan/Form/Binding/BoundData.php
@@ -37,23 +37,15 @@ class BoundData
         $key = $keyParts[0];
         $remainingKeys = array_slice($keyParts, 1);
 
-        if (is_array($target)) {
-            return isset($target[$key]) ? $this->dataGet($target[$key], $remainingKeys) : false;
+        if (is_array($target) && isset($target[$key])) {
+            return $this->dataGet($target[$key], $remainingKeys);
         }
 
-        try {
-            if (property_exists($target, $key)) {
-                $this->dataGet($target->{$key}, $remainingKeys);
-            } elseif (method_exists($target, '__get')) {
-                $this->dataGet($target->__get($key), $remainingKeys);
-            } else {
-                return false;
-            }
-        } catch (Exception $exception) {
-            return false;
+        if (property_exists($target, $key) || method_exists($target, '__get')) {
+            return $this->dataGet($target->{$key}, $remainingKeys);
         }
 
-        return $this->dataGet($target->{$key}, $remainingKeys);
+        return false;
     }
 
     protected function transformKey($key)

--- a/src/AdamWathan/Form/Binding/BoundData.php
+++ b/src/AdamWathan/Form/Binding/BoundData.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace AdamWathan\Form\Binding;
+
+class BoundData
+{
+    protected $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function has($name)
+    {
+        return $this->dotGet($this->transformKey($name)) !== false;
+    }
+
+    public function get($name)
+    {
+        return $this->dotGet($this->transformKey($name));
+    }
+
+    protected function dotGet($dotKey)
+    {
+        $keyParts = array_filter(explode('.', $dotKey));
+
+        return $this->dataGet($this->data, $keyParts);
+    }
+
+    protected function dataGet($target, $keyParts)
+    {
+        if (count($keyParts) == 0) {
+            return $target;
+        }
+
+        $key = $keyParts[0];
+        $remainingKeys = array_slice($keyParts, 1);
+
+        if (is_array($target)) {
+            return isset($target[$key]) ? $this->dataGet($target[$key], $remainingKeys) : false;
+        }
+
+        return isset($target->{$key}) ? $this->dataGet($target->{$key}, $remainingKeys) : false;
+    }
+
+    protected function transformKey($key)
+    {
+        return str_replace(['[]', '[', ']'], ['', '.', ''], $key);
+    }
+}

--- a/src/AdamWathan/Form/Binding/BoundData.php
+++ b/src/AdamWathan/Form/Binding/BoundData.php
@@ -41,7 +41,19 @@ class BoundData
             return isset($target[$key]) ? $this->dataGet($target[$key], $remainingKeys) : false;
         }
 
-        return isset($target->{$key}) ? $this->dataGet($target->{$key}, $remainingKeys) : false;
+        try {
+            if (property_exists($target, $key)) {
+                $this->dataGet($target->{$key}, $remainingKeys);
+            } elseif (method_exists($target, '__get')) {
+                $this->dataGet($target->__get($key), $remainingKeys);
+            } else {
+                return false;
+            }
+        } catch (Exception $exception) {
+            return false;
+        }
+
+        return $this->dataGet($target->{$key}, $remainingKeys);
     }
 
     protected function transformKey($key)

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -27,7 +27,7 @@ class FormBuilder
 
     protected $csrfToken;
 
-    protected $model;
+    protected $boundData;
 
     public function setOldInputProvider(OldInputInterface $oldInputProvider)
     {
@@ -62,7 +62,7 @@ class FormBuilder
 
     public function close()
     {
-        $this->unbindModel();
+        $this->unbindData();
 
         return '</form>';
     }
@@ -221,7 +221,7 @@ class FormBuilder
 
     public function bind($data)
     {
-        $this->model = new BoundData($data);
+        $this->boundData = new BoundData($data);
     }
 
     public function getValueFor($name)
@@ -230,8 +230,8 @@ class FormBuilder
             return $this->getOldInput($name);
         }
 
-        if ($this->hasModelValue($name)) {
-            return $this->getModelValue($name);
+        if ($this->hasBoundValue($name)) {
+            return $this->getBoundValue($name);
         }
 
         return null;
@@ -251,18 +251,18 @@ class FormBuilder
         return $this->escape($this->oldInput->getOldInput($name));
     }
 
-    protected function hasModelValue($name)
+    protected function hasBoundValue($name)
     {
-        if (! isset($this->model)) {
+        if (! isset($this->boundData)) {
             return false;
         }
 
-        return $this->model->has($name);
+        return $this->boundData->has($name);
     }
 
-    protected function getModelValue($name)
+    protected function getBoundValue($name)
     {
-        return $this->escape($this->model->get($name));
+        return $this->escape($this->boundData->get($name));
     }
 
     protected function escape($value)
@@ -274,9 +274,9 @@ class FormBuilder
         return htmlentities($value, ENT_QUOTES, 'UTF-8');
     }
 
-    protected function unbindModel()
+    protected function unbindData()
     {
-        $this->model = null;
+        $this->boundData = null;
     }
 
     public function selectMonth($name)

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -2,6 +2,7 @@
 
 namespace AdamWathan\Form;
 
+use AdamWathan\Form\Binding\BoundData;
 use AdamWathan\Form\Elements\Button;
 use AdamWathan\Form\Elements\Checkbox;
 use AdamWathan\Form\Elements\Date;
@@ -26,7 +27,7 @@ class FormBuilder
 
     private $csrfToken;
 
-    private $model;
+    public $model;
 
     public function setOldInputProvider(OldInputInterface $oldInputProvider)
     {
@@ -218,9 +219,9 @@ class FormBuilder
         return $message;
     }
 
-    public function bind($model)
+    public function bind($data)
     {
-        $this->model = is_array($model) ? (object) $model : $model;
+        $this->model = new BoundData($data);
     }
 
     public function getValueFor($name)
@@ -256,21 +257,17 @@ class FormBuilder
             return false;
         }
 
-        $name = $this->transformKey($name);
-
-        return isset($this->model->{$name}) || method_exists($this->model, '__get');
+        return $this->model->has($name);
     }
 
     protected function getModelValue($name)
     {
-        $name = $this->transformKey($name);
-
-        return $this->escape($this->model->{$name});
+        return $this->escape($this->model->get($name));
     }
 
     protected function escape($value)
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return $value;
         }
 
@@ -300,10 +297,5 @@ class FormBuilder
         ];
 
         return $this->select($name, $options);
-    }
-
-    protected function transformKey($key)
-    {
-        return str_replace('[]', '', $key);
     }
 }

--- a/tests/BindingTest.php
+++ b/tests/BindingTest.php
@@ -136,8 +136,12 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $object = new MagicGetter;
         $this->form->bind($object);
 
-        $expected = '<input type="text" name="not_set" value="foo">';
-        $result = (string) $this->form->text('not_set');
+        $expected = '<input type="text" name="not_magic" value="foo">';
+        $result = (string) $this->form->text('not_magic');
+        $this->assertEquals($expected, $result);
+
+        $expected = '<input type="text" name="magic" value="bar">';
+        $result = (string) $this->form->text('magic');
         $this->assertEquals($expected, $result);
     }
 
@@ -376,8 +380,10 @@ class BindingTest extends PHPUnit_Framework_TestCase
 
 class MagicGetter
 {
+    public $not_magic = 'foo';
+
     public function __get($key)
     {
-        return 'foo';
+        return 'bar';
     }
 }

--- a/tests/BindingTest.php
+++ b/tests/BindingTest.php
@@ -220,7 +220,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testCloseUnbindsModel()
+    public function testCloseUnbindsData()
     {
         $object = $this->getStubObject();
         $this->form->bind($object);
@@ -231,7 +231,7 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testAgainstXSSAttacksInBoundModels()
+    public function testAgainstXSSAttacksInBoundData()
     {
         $object = $this->getStubObject();
         $object->first_name = '" onmouseover="alert(\'xss\')';

--- a/tests/BindingTest.php
+++ b/tests/BindingTest.php
@@ -143,11 +143,34 @@ class BindingTest extends PHPUnit_Framework_TestCase
 
     public function testBindArray()
     {
-        $model = ['first_name' => 'John'];
-        $this->form->bind($model);
+        $array = ['first_name' => 'John'];
+        $this->form->bind($array);
 
         $expected = '<input type="text" name="first_name" value="John">';
         $result = (string) $this->form->text('first_name');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testBindNestedArray()
+    {
+        $array = [
+            'address' => [
+                'city' => 'Roswell',
+                'tree' => [
+                    'has' => [
+                        'nested' => 'Bird'
+                    ]
+                ],
+            ],
+        ];
+        $this->form->bind($array);
+
+        $expected = '<input type="text" name="address[city]" value="Roswell">';
+        $result = (string) $this->form->text('address[city]');
+        $this->assertEquals($expected, $result);
+
+        $expected = '<input type="text" name="address[tree][has][nested]" value="Bird">';
+        $result = (string) $this->form->text('address[city][has][nested]');
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/BindingTest.php
+++ b/tests/BindingTest.php
@@ -170,7 +170,53 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
 
         $expected = '<input type="text" name="address[tree][has][nested]" value="Bird">';
-        $result = (string) $this->form->text('address[city][has][nested]');
+        $result = (string) $this->form->text('address[tree][has][nested]');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testBindNestedObject()
+    {
+        $object = json_decode(json_encode([
+            'address' => [
+                'city' => 'Roswell',
+                'tree' => [
+                    'has' => [
+                        'nested' => 'Bird'
+                    ]
+                ],
+            ],
+        ]));
+        $this->form->bind($object);
+
+        $expected = '<input type="text" name="address[city]" value="Roswell">';
+        $result = (string) $this->form->text('address[city]');
+        $this->assertEquals($expected, $result);
+
+        $expected = '<input type="text" name="address[tree][has][nested]" value="Bird">';
+        $result = (string) $this->form->text('address[tree][has][nested]');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testBindNestedMixed()
+    {
+        $object = [
+            'address' => [
+                'city' => 'Roswell',
+                'tree' => json_decode(json_encode([
+                    'has' => [
+                        'nested' => 'Bird'
+                    ]
+                ])),
+            ],
+        ];
+        $this->form->bind($object);
+
+        $expected = '<input type="text" name="address[city]" value="Roswell">';
+        $result = (string) $this->form->text('address[city]');
+        $this->assertEquals($expected, $result);
+
+        $expected = '<input type="text" name="address[tree][has][nested]" value="Bird">';
+        $result = (string) $this->form->text('address[tree][has][nested]');
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
This PR adds support for binding nested array/object/mixed data, using the new BoundData object helpers you helped me with.  I've added test coverage as well.

It's looking good, except for one regression...

<img width="414" alt="screen shot 2016-03-25 at 1 06 32 am" src="https://cloud.githubusercontent.com/assets/5187394/14038367/e8192624-f225-11e5-8a17-26ba413bf32d.png">

**UPDATE:** I fixed this regression...

<img width="252" alt="screen shot 2016-03-25 at 2 06 29 am" src="https://cloud.githubusercontent.com/assets/5187394/14039050/3d197108-f22e-11e5-99e9-f22dee37f7e0.png">
