### PR TITLE
Unnecessary array_filter?

### DIFF
--- a/src/AdamWathan/Form/Binding/BoundData.php
+++ b/src/AdamWathan/Form/Binding/BoundData.php
@@ -23,7 +23,7 @@ class BoundData
 
     protected function dotGet($dotKey, $default)
     {
-        $keyParts = array_filter(explode('.', $dotKey));
+        $keyParts = explode('.', $dotKey);
 
         return $this->dataGet($this->data, $keyParts, $default);
     }

--- a/tests/BindingTest.php
+++ b/tests/BindingTest.php
@@ -205,6 +205,26 @@ class BindingTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testBindArrayWithZeroAsKey()
+    {
+        $array = [
+            'hotdog' => [
+                0 => 'Tube',
+                1 => 'Steak',
+            ],
+        ];
+
+        $this->form->bind($array);
+
+        $expected = '<input type="text" name="hotdog[0]" value="Tube">';
+        $result = (string) $this->form->text('hotdog[0]');
+        $this->assertEquals($expected, $result);
+
+        $expected = '<input type="text" name="hotdog[1]" value="Steak">';
+        $result = (string) $this->form->text('hotdog[1]');
+        $this->assertEquals($expected, $result);
+    }
+
     public function testBindNestedObject()
     {
         $object = json_decode(json_encode([


### PR DESCRIPTION
I found an issue where `array_filter` in BoundData is causing binding issues with simple array elements where key is 0 (zero).  This PR adds a failing test to prove the issue, and suggests removal of that array_filter call.  Do you see any issue with this?