### PR TITLE
Enhancement/get all errors

### DIFF
--- a/src/AdamWathan/Form/ErrorStore/ErrorStoreInterface.php
+++ b/src/AdamWathan/Form/ErrorStore/ErrorStoreInterface.php
@@ -4,7 +4,11 @@ namespace AdamWathan\Form\ErrorStore;
 
 interface ErrorStoreInterface
 {
+    public function hasErrors();
+
     public function hasError($key);
+
+    public function getErrors();
 
     public function getError($key);
 }

--- a/src/AdamWathan/Form/ErrorStore/IlluminateErrorStore.php
+++ b/src/AdamWathan/Form/ErrorStore/IlluminateErrorStore.php
@@ -35,12 +35,12 @@ class IlluminateErrorStore implements ErrorStoreInterface
         return $this->getErrors()->first($key);
     }
 
-    protected function hasErrors()
+    public function hasErrors()
     {
         return $this->session->has('errors');
     }
 
-    protected function getErrors()
+    public function getErrors()
     {
         return $this->hasErrors() ? $this->session->get('errors') : null;
     }

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -191,6 +191,11 @@ class FormBuilder
         return $token;
     }
 
+    public function hasErrors()
+    {
+        return $this->errorStore->hasErrors();
+    }
+
     public function hasError($name)
     {
         if (! isset($this->errorStore)) {
@@ -198,6 +203,11 @@ class FormBuilder
         }
 
         return $this->errorStore->hasError($name);
+    }
+
+    public function getErrors()
+    {
+        return $this->errorStore->getErrors();
     }
 
     public function getError($name, $format = null)

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -207,7 +207,11 @@ class FormBuilder
 
     public function getErrors()
     {
-        return $this->errorStore->getErrors();
+        if(! $this->hasErrors()){
+            return null;
+        }
+
+        return $this->errorStore->getErrors()->all();
     }
 
     public function getError($name, $format = null)

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use AdamWathan\Form\FormBuilder;
+use Illuminate\Support\MessageBag;
 
 class FormBuilderTest extends PHPUnit_Framework_TestCase
 {
@@ -182,6 +183,23 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result);
     }
 
+    public function testCanCheckForErrorMessages()
+    {
+        $errorStore = Mockery::mock('AdamWathan\Form\ErrorStore\ErrorStoreInterface');
+        $errorStore->shouldReceive('hasErrors')->andReturn(true);
+
+        $this->form->setErrorStore($errorStore);
+
+        $this->assertTrue($this->form->hasErrors());
+
+        $errorStore = Mockery::mock('AdamWathan\Form\ErrorStore\ErrorStoreInterface');
+        $errorStore->shouldReceive('hasErrors')->andReturn(false);
+
+        $this->form->setErrorStore($errorStore);
+
+        $this->assertFalse($this->form->hasErrors());
+    }
+
     public function testCanRetrieveErrorMessage()
     {
         $errorStore = Mockery::mock('AdamWathan\Form\ErrorStore\ErrorStoreInterface');
@@ -192,6 +210,19 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
         $expected = 'The e-mail address is invalid.';
         $result = $this->form->getError('email');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testCanRetrieveErrorMessages()
+    {
+        $errors = new MessageBag(['foo.bar' => 'Some error']);
+        $errorStore = Mockery::mock('AdamWathan\Form\ErrorStore\ErrorStoreInterface');
+        $errorStore->shouldReceive('getErrors')->andReturn($errors);
+
+        $this->form->setErrorStore($errorStore);
+
+        $expected = $errors;
+        $result = $this->form->getErrors();
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -217,11 +217,22 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
     {
         $errors = new MessageBag(['foo.bar' => 'Some error']);
         $errorStore = Mockery::mock('AdamWathan\Form\ErrorStore\ErrorStoreInterface');
+        $errorStore->shouldReceive('hasErrors')->andReturn(true);
         $errorStore->shouldReceive('getErrors')->andReturn($errors);
 
         $this->form->setErrorStore($errorStore);
 
-        $expected = $errors;
+        $expected = $errors->all();
+        $result = $this->form->getErrors();
+        $this->assertEquals($expected, $result);
+
+        $errorStore = Mockery::mock('AdamWathan\Form\ErrorStore\ErrorStoreInterface');
+        $errorStore->shouldReceive('hasErrors')->andReturn(false);
+        $errorStore->shouldReceive('getErrors')->andReturn(null);
+
+        $this->form->setErrorStore($errorStore);
+
+        $expected = null;
         $result = $this->form->getErrors();
         $this->assertEquals($expected, $result);
     }

--- a/tests/IlluminateErrorStoreTest.php
+++ b/tests/IlluminateErrorStoreTest.php
@@ -15,4 +15,17 @@ class IlluminateErrorStoreTest extends PHPUnit_Framework_TestCase
         $errorStore = new IlluminateErrorStore($session);
         $this->assertTrue($errorStore->hasError('foo[bar]'));
     }
+
+    public function test_it_returns_all_errors()
+    {
+        $errors = new MessageBag(['foo.bar' => 'Some error']);
+        $session = Mockery::mock('Illuminate\Session\Store');
+        $session->shouldReceive('has')->with('errors')->andReturn(true);
+        $session->shouldReceive('get')->with('errors')->andReturn($errors);
+
+        $errorStore = new IlluminateErrorStore($session);
+        $this->assertTrue($errorStore->hasErrors());
+        $this->assertEquals($errorStore->getErrors(), $errors);
+    }
+
 }


### PR DESCRIPTION
Hi.

I think I'd be very nice to have a way to check if a form contains errors and a way to retrieve all of them. This would be helpful to know the state of a form and update the UI accordingly.

For example:
```
<?php if ($form->hasErrors()): ?>
    <span class="error">The form contains the following errors, please fix.</span>
    <ul>
    <?php foreach ($form->hasErrors() as $error): ?>
        <li><?php echo $error; ?></li>
    <?php endforeach; ?>
    </ul>
<?php endif; ?>
```