### PR TITLE
add Htmlable, so {{ can be used instead of the "dirty" {!!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "illuminate/support": "4.*",
+        "illuminate/support": "5.*",
         "phpunit/phpunit": "3.7.*",
         "mockery/mockery": "~0.9",
         "satooshi/php-coveralls": "^1.0"

--- a/src/AdamWathan/Form/Elements/Element.php
+++ b/src/AdamWathan/Form/Elements/Element.php
@@ -2,7 +2,9 @@
 
 namespace AdamWathan\Form\Elements;
 
-abstract class Element
+use Illuminate\Contracts\Support\Htmlable;
+
+abstract class Element implements Htmlable
 {
     protected $attributes = [];
 
@@ -133,5 +135,14 @@ abstract class Element
         call_user_func_array([$this, 'attribute'], $params);
 
         return $this;
+    }
+
+    /**
+     * Get content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml() {
+        return $this->render();
     }
 }

--- a/src/AdamWathan/Form/Elements/FormClose.php
+++ b/src/AdamWathan/Form/Elements/FormClose.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AdamWathan\Form\Elements;
+
+/**
+ * Class FormClose
+ * @package AdamWathan\Form\Elements
+ */
+class FormClose extends Element
+{
+    /**
+     * @return string
+     */
+    public function render()
+    {
+        return '</form>';
+    }
+}

--- a/src/AdamWathan/Form/FormBuilder.php
+++ b/src/AdamWathan/Form/FormBuilder.php
@@ -9,6 +9,7 @@ use AdamWathan\Form\Elements\Date;
 use AdamWathan\Form\Elements\Email;
 use AdamWathan\Form\Elements\File;
 use AdamWathan\Form\Elements\FormOpen;
+use AdamWathan\Form\Elements\FormClose;
 use AdamWathan\Form\Elements\Hidden;
 use AdamWathan\Form\Elements\Label;
 use AdamWathan\Form\Elements\Password;
@@ -60,11 +61,14 @@ class FormBuilder
         return isset($this->csrfToken);
     }
 
+    /**
+     * @return FormClose
+     */
     public function close()
     {
         $this->unbindData();
 
-        return '</form>';
+        return new FormClose;
     }
 
     public function text($name)

--- a/tests/FormCloseTest.php
+++ b/tests/FormCloseTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use AdamWathan\Form\Elements\FormClose;
+
+class FormCloseTest extends PHPUnit_Framework_TestCase
+{
+    public function testFormCanBeCreated()
+    {
+        $form = new FormClose;
+    }
+
+    public function testRenderBasicFormClose()
+    {
+        $form = new FormClose;
+        $expected = '</form>';
+        $result = $form->render();
+
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/InputContractTest.php
+++ b/tests/InputContractTest.php
@@ -25,6 +25,16 @@ trait InputContractTest
         $this->assertRegExp($this->elementRegExp('required="required"'), $result, $message);
     }
 
+    public function testHtmlableInterface()
+    {
+        $text = $this->newTestSubjectInstance('email');
+
+        $expected = $text->render();
+        $result = $text->toHtml();
+        $message = 'Casting input element to HTML should return the rendered element';
+        $this->assertEquals($expected, $result, $message);
+    }
+
     public function testAutofocus()
     {
         $text = $this->newTestSubjectInstance('');


### PR DESCRIPTION
Make all Elements/Groups Htmlable so the Helper can used "clean" 
`{{ Form::text() }}` instead of `{!! Form::text() !!}`
