### PR TITLE
Conditional element method calls

### DIFF
--- a/src/AdamWathan/Form/Elements/Element.php
+++ b/src/AdamWathan/Form/Elements/Element.php
@@ -126,8 +126,24 @@ abstract class Element
         return [$keys, $values];
     }
 
+    protected function conditionalMethodCall($method, $params)
+    {
+        $condition = array_shift($params);
+        $method = substr($method, 0, -2);
+
+        if ($condition) {
+            return call_user_func_array([$this, $method], $params);
+        }
+
+        return $this;
+    }
+
     public function __call($method, $params)
     {
+        if (substr($method, -2) === 'If') {
+            return $this->conditionalMethodCall($method, $params);
+        }
+
         $params = count($params) ? $params : [$method];
         $params = array_merge([$method], $params);
         call_user_func_array([$this, 'attribute'], $params);

--- a/tests/TextAreaTest.php
+++ b/tests/TextAreaTest.php
@@ -143,4 +143,31 @@ class TextAreaTest extends PHPUnit_Framework_TestCase
         $result = $text->render();
         $this->assertEquals($expected, $result);
     }
+
+    public function testCanConditionallyAddAttributesThroughMagicMethods()
+    {
+        $text = new TextArea('loldogz');
+        $text = $text->disabledIf(false);
+        $expected = '<textarea name="loldogz" rows="10" cols="50"></textarea>';
+        $result = $text->render();
+        $this->assertEquals($expected, $result);
+
+        $text = new TextArea('lolcatz');
+        $text = $text->disabledIf(true);
+        $expected = '<textarea name="lolcatz" rows="10" cols="50" disabled="disabled"></textarea>';
+        $result = $text->render();
+        $this->assertEquals($expected, $result);
+
+        $text = new TextArea('gluteous');
+        $text = $text->maxlengthIf(false, '5');
+        $expected = '<textarea name="gluteous" rows="10" cols="50"></textarea>';
+        $result = $text->render();
+        $this->assertEquals($expected, $result);
+
+        $text = new TextArea('maximus');
+        $text = $text->maxlengthIf(true, '5');
+        $expected = '<textarea name="maximus" rows="10" cols="50" maxlength="5"></textarea>';
+        $result = $text->render();
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
Similar to the existing magic attribute setters:

```php
Form::text('meme')->lol('catz')
// <input type="text" name="meme" lol="catz">
```

This PR proposes conditional magic attribute setters:

```php
Form::text('meme')->disabledIf(true)
// <input type="text" name="meme" disabled="disabled">

Form::text('meme')->disabledIf(false)
// <input type="text" name="meme">

Form::text('meme')->maxlengthIf(true, '5')
// <input type="text" name="meme" maxlength="5">

Form::text('meme')->maxlengthIf(false, '5')
// <input type="text" name="meme">
```

The first param being `$condition` (can be any expression), and the following params are just passed onto the desired method using `call_user_func_array()`.