### PR TITLE
Populate model bound forms using form model accessor if set

### DIFF
--- a/src/AdamWathan/Form/Binding/BoundData.php
+++ b/src/AdamWathan/Form/Binding/BoundData.php
@@ -64,6 +64,10 @@ class BoundData
             return $default;
         }
 
+        if (method_exists($target, 'getFormValue')) {
+            return $this->data->getFormValue($key);
+        }
+
         return $this->dataGet($target->{$key}, $keyParts, $default);
     }
 


### PR DESCRIPTION
This change enables use of Laravel's Form Model Accessors as detailed in the below documentation (documentation refers to 5.2, changes developed and tested in 5.3)
https://laravelcollective.com/docs/5.2/html#form-model-binding

The additional code uses the Form Model Accessor only if the method exists otherwise reverting to the original behaviour of using the standard model accessor.
This should mean that existing implementations are unaffected by the change.

The advantage of this change is that the value returned for binding a model to a form can be handled separately to the value returned by the standard model accessor. In my case I wish the value for the date attribute of one of my models to be formatted as a string when populating form fields, but to be a carbon date object for use in my reporting and metrics.