### PR TITLE
Fix PHP warning by converting DateTime object in defaultValue

### DIFF
--- a/src/AdamWathan/Form/Elements/Date.php
+++ b/src/AdamWathan/Form/Elements/Date.php
@@ -16,4 +16,16 @@ class Date extends Text
 
         return parent::value($value);
     }
+
+    public function defaultValue($value)
+    {
+        if (! $this->hasValue()) {
+            if ($value instanceof \DateTime) {
+                $value = $value->format('Y-m-d');
+            }
+            $this->setValue($value);
+        }
+
+        return $this;
+    }
 }

--- a/src/AdamWathan/Form/Elements/DateTimeLocal.php
+++ b/src/AdamWathan/Form/Elements/DateTimeLocal.php
@@ -16,4 +16,16 @@ class DateTimeLocal extends Text
 
         return parent::value($value);
     }
+
+    public function defaultValue($value)
+    {
+        if (! $this->hasValue()) {
+            if ($value instanceof \DateTime) {
+                $value = $value->format('Y-m-d\TH:i');
+            }
+            $this->setValue($value);
+        }
+
+        return $this;
+    }
 }

--- a/tests/DateTest.php
+++ b/tests/DateTest.php
@@ -15,4 +15,22 @@ class DateTest extends PHPUnit_Framework_TestCase
     {
         return 'date';
     }
+
+    public function testDateTimeValuesAreBoundAsFormattedStrings()
+    {
+        $dateTimeLocal = new Date('dob');
+        $dateTimeLocal->defaultValue(new DateTime('12-04-1988 10:33'));
+
+        $expected = '<input type="date" name="dob" value="1988-04-12">';
+        $this->assertSame($expected, $dateTimeLocal->render());
+    }
+
+    public function testDateTimeDefaultValuesAreBoundAsFormattedStrings()
+    {
+        $dateTimeLocal = new Date('dob');
+        $dateTimeLocal->defaultValue(new DateTime('12-04-1988 10:33'));
+
+        $expected = '<input type="date" name="dob" value="1988-04-12">';
+        $this->assertSame($expected, $dateTimeLocal->render());
+    }
 }

--- a/tests/DateTest.php
+++ b/tests/DateTest.php
@@ -18,19 +18,19 @@ class DateTest extends PHPUnit_Framework_TestCase
 
     public function testDateTimeValuesAreBoundAsFormattedStrings()
     {
-        $dateTimeLocal = new Date('dob');
-        $dateTimeLocal->defaultValue(new DateTime('12-04-1988 10:33'));
+        $date = new Date('dob');
+        $date->defaultValue(new DateTime('12-04-1988 10:33'));
 
         $expected = '<input type="date" name="dob" value="1988-04-12">';
-        $this->assertSame($expected, $dateTimeLocal->render());
+        $this->assertSame($expected, $date->render());
     }
 
     public function testDateTimeDefaultValuesAreBoundAsFormattedStrings()
     {
-        $dateTimeLocal = new Date('dob');
-        $dateTimeLocal->defaultValue(new DateTime('12-04-1988 10:33'));
+        $date = new Date('dob');
+        $date->defaultValue(new DateTime('12-04-1988 10:33'));
 
         $expected = '<input type="date" name="dob" value="1988-04-12">';
-        $this->assertSame($expected, $dateTimeLocal->render());
+        $this->assertSame($expected, $date->render());
     }
 }

--- a/tests/DateTimeLocalTest.php
+++ b/tests/DateTimeLocalTest.php
@@ -24,4 +24,13 @@ class DateTimeLocalTest extends PHPUnit_Framework_TestCase
         $expected = '<input type="datetime-local" name="dob" value="1988-04-12T10:33">';
         $this->assertSame($expected, $dateTimeLocal->render());
     }
+
+    public function testDateTimeDefaultValuesAreBoundAsFormattedStrings()
+    {
+        $dateTimeLocal = new DateTimeLocal('dob');
+        $dateTimeLocal->defaultValue(new DateTime('12-04-1988 10:33'));
+
+        $expected = '<input type="datetime-local" name="dob" value="1988-04-12T10:33">';
+        $this->assertSame($expected, $dateTimeLocal->render());
+    }
 }


### PR DESCRIPTION
There is a PHP warning when setting a DateTime as Date::defaultValue() on the date fields.
In Date::value() these are accepted.
The warning is fixed by formatting the DateTime objects to a string in an added defaultValue method.