### PR TITLE
Made ability to add option attributes for the Select element.

### DIFF
--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -8,6 +8,8 @@ class Select extends FormControl
 
     protected $selected;
 
+    protected $optAttributes = [];
+
     public function __construct($name, $options = [])
     {
         $this->setName($name);
@@ -73,9 +75,10 @@ class Select extends FormControl
 
     protected function renderOption($value, $label)
     {
-        return vsprintf('<option value="%s"%s>%s</option>', [
+        return vsprintf('<option value="%s"%s%s>%s</option>', [
             $this->escape($value),
             $this->isSelected($value) ? ' selected' : '',
+            $this->renderOptAttributes($value),
             $this->escape($label),
         ]);
     }
@@ -114,5 +117,51 @@ class Select extends FormControl
         $this->setAttribute('multiple', 'multiple');
 
         return $this;
+    }
+
+    public function setOptAttributes($optAttributes = [])
+    {
+        $this->optAttributes = $optAttributes;
+        return $this;
+    }
+
+    public function addOptAttribute($optValue, $name, $value)
+    {
+        $this->optAttributes[$optValue][$name] = $value;
+        return $this;
+    }
+
+    public function removeOptAttribute($optValue, $name = null)
+    {
+        if ($name === null) {
+            unset($this->optAttributes[$optValue]);
+        } else {
+            unset($this->optAttributes[$optValue][$name]);
+        }
+        return $this;
+    }
+
+    public function getOptAttribute($optValue, $name)
+    {
+        if (isset($this->optAttributes[$optValue][$name])) {
+            return $this->optAttributes[$optValue][$name];
+        }
+        return null;
+    }
+
+    protected function renderOptAttributes($optValue)
+    {
+        if (empty($this->optAttributes[$optValue])) {
+            return '';
+        }
+
+        list($attributes, $values) = $this->splitKeysAndValues($this->optAttributes[$optValue]);
+
+        return implode(array_map(function ($attribute, $value) {
+            if (is_bool($value)) {
+                return $value ? " {$attribute}" : '';
+            }
+            return sprintf(' %s="%s"', $attribute, $this->escape($value));
+        }, $attributes, $values));
     }
 }

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -272,4 +272,89 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testSetOptAttributes()
+    {
+        $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
+        $select->setOptAttributes([
+            'red' => [
+                'data-attribute' => 'some value',
+                'label' => 'This is Red',
+                'disabled' => true,
+            ],
+        ]);
+        $expected = '<select name="color"><option value="red" data-attribute="some value" label="This is Red" disabled>Red</option><option value="blue">Blue</option></select>';
+        $result = $select->render();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testAddOptAttribute()
+    {
+        $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
+        $select->setOptAttributes([
+            'red' => [
+                'data-attribute' => 'some value',
+                'label' => 'This is Red',
+                'disabled' => true,
+            ],
+        ]);
+        $select->addOptAttribute('blue', 'label', 'This is Blue');
+        $expected = '<select name="color"><option value="red" data-attribute="some value" label="This is Red" disabled>Red</option><option value="blue" label="This is Blue">Blue</option></select>';
+        $result = $select->render();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testRemoveOptAttributes()
+    {
+        $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
+        $select->setOptAttributes([
+            'red' => [
+                'data-attribute' => 'some value',
+                'label' => 'This is Red',
+                'disabled' => true,
+            ],
+        ]);
+        $select->removeOptAttribute('red', 'disabled');
+        $expected = '<select name="color"><option value="red" data-attribute="some value" label="This is Red">Red</option><option value="blue">Blue</option></select>';
+        $result = $select->render();
+        $this->assertEquals($expected, $result);
+
+        $select->removeOptAttribute('red');
+        $expected = '<select name="color"><option value="red">Red</option><option value="blue">Blue</option></select>';
+        $result = $select->render();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetOptAttribute()
+    {
+        $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
+        $select->setOptAttributes([
+            'red' => [
+                'data-attribute' => 'some value',
+                'label' => 'This is Red',
+                'disabled' => true,
+            ],
+        ]);
+        $this->assertEquals('some value', $select->getOptAttribute('red', 'data-attribute'));
+        $this->assertEquals(null, $select->getOptAttribute('blue', 'disabled'));
+        $this->assertEquals(null, $select->getOptAttribute('red', 'data-invalid-attribute'));
+    }
+
+    public function testBoolTypeOptAttribute()
+    {
+        $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
+        $select->setOptAttributes([
+            'red' => ['disabled' => true],
+        ]);
+        $expected = '<select name="color"><option value="red" disabled>Red</option><option value="blue">Blue</option></select>';
+        $result = $select->render();
+        $this->assertEquals($expected, $result);
+
+        $select->setOptAttributes([
+            'red' => ['disabled' => false],
+        ]);
+        $expected = '<select name="color"><option value="red">Red</option><option value="blue">Blue</option></select>';
+        $result = $select->render();
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
Option attributes is very important feature for Select element. I have added it to one element. Now, we can do follow:

```php
echo (new Select('age', ['10' => 'Teen', 20 => 'Twenty'])->setOptAttributes([10 => ['data-key' => 'some-key']]);
```

and we got result:

```html
<select name="age">
    <option value="10" data-key="some-key">Teen</option>
    <option value="20">Twenty</option>
</select>
```

It's beaniful, isn't it? =)