### PR TITLE
Made ability to add prompt for Select element

### DIFF
--- a/src/AdamWathan/Form/Elements/Select.php
+++ b/src/AdamWathan/Form/Elements/Select.php
@@ -115,4 +115,10 @@ class Select extends FormControl
 
         return $this;
     }
+
+    public function prompt($label = '', $value = '')
+    {
+        $this->options = [$value => $label] + $this->options;
+        return $this;
+    }
 }

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -272,4 +272,17 @@ class SelectTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testPrompt()
+    {
+        $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
+        $select->prompt();
+        $expected = '<select name="color"><option value=""></option><option value="red">Red</option><option value="blue">Blue</option></select>';
+        $this->assertEquals($expected, $select->render());
+
+        $select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
+        $select->prompt('Nothing selected', -1);
+        $expected = '<select name="color"><option value="-1">Nothing selected</option><option value="red">Red</option><option value="blue">Blue</option></select>';
+        $this->assertEquals($expected, $select->render());
+    }
 }


### PR DESCRIPTION
We have:
```php
$select = new Select('color', ['red' => 'Red', 'blue' => 'Blue']);
$select->prompt();
echo $select;
```

Result:
```html
<select name="color">
    <option value=""></option>
    <option value="red">Red</option>
    <option value="blue">Blue</option>
</select>
```